### PR TITLE
Restructure path response to include coordinates

### DIFF
--- a/app/classes/sensor.py
+++ b/app/classes/sensor.py
@@ -1,8 +1,10 @@
 class Sensor:
     def __init__(self, id: str, room_ids: list):
         self.id = id
-        self.room_ids = room_ids  # List of room IDs (as provided by the API)
-        self.rooms = []  # This will later hold full Room objects
+        self.room_ids = room_ids
+        self.rooms = []
+        self.longtitude = 0.0
+        self.latitude = 0.0
 
     @classmethod
     def from_dict(cls, data: dict):

--- a/app/classes/sensor.py
+++ b/app/classes/sensor.py
@@ -1,14 +1,19 @@
 class Sensor:
-    def __init__(self, id: str, room_ids: list):
+    def __init__(self, id: str, room_ids: list, longitude: float, latitude: float):
         self.id = id
         self.room_ids = room_ids
         self.rooms = []
-        self.longtitude = 0.0
-        self.latitude = 0.0
+        self.longitude = longitude
+        self.latitude = latitude
 
     @classmethod
     def from_dict(cls, data: dict):
-        return cls(id=data.get('id'), room_ids=data.get('rooms', []))
+        return cls(
+                    id=data.get('id'),
+                    room_ids=data.get('rooms', []), 
+                    longitude=data.get('longitude'),
+                    latitude=data.get('latitude')
+                )
 
     @classmethod
     def from_schema(cls, schema):
@@ -16,7 +21,7 @@ class Sensor:
         Factory that creates a Sensor from a Pydantic schema instance
         (for example, SensorSchema).
         """
-        return cls(id=schema.id, room_ids=schema.rooms)
+        return cls(id=schema.id, room_ids=schema.rooms, longitude=schema.longitude, latitude=schema.latitude)
 
     @classmethod
     def create_sensors_from_schemas(cls, sensor_schemas: list, room_mapping: dict):

--- a/app/classes/sensor_graph.py
+++ b/app/classes/sensor_graph.py
@@ -46,7 +46,16 @@ class SensorGraph:
         """
         try:
             path = nx.dijkstra_path(self.graph, source, target, weight='weight')
+            path_with_coordinates = []
+            for sensor in path:
+                path_with_coordinates.append(
+                    {
+                        "id": sensor,
+                        "longtitude": self.graph.nodes[sensor]["sensor"].longtitude,
+                        "latitude": self.graph.nodes[sensor]["sensor"].latitude,
+                    }
+                )
             distance = nx.dijkstra_path_length(self.graph, source, target, weight='weight')
-            return path, distance
+            return path_with_coordinates, distance
         except nx.NetworkXNoPath:
             return None, None

--- a/app/classes/sensor_graph.py
+++ b/app/classes/sensor_graph.py
@@ -51,7 +51,7 @@ class SensorGraph:
                 path_with_coordinates.append(
                     {
                         "id": sensor,
-                        "longtitude": self.graph.nodes[sensor]["sensor"].longtitude,
+                        "longitude": self.graph.nodes[sensor]["sensor"].longitude,
                         "latitude": self.graph.nodes[sensor]["sensor"].latitude,
                     }
                 )

--- a/app/schemas/sensor.py
+++ b/app/schemas/sensor.py
@@ -5,4 +5,5 @@ from typing import List
 class SensorSchema(BaseModel):
     id: str = Field(..., description="Unique identifier for the sensor.")
     rooms: List[str] = Field(..., description="List of room UUIDs associated with the sensor.")
-
+    longitude: float = Field(..., description="Longitude of the sensor's location.")
+    latitude: float = Field(..., description="Latitude of the sensor's location.")

--- a/app/test/classes/test_sensor.py
+++ b/app/test/classes/test_sensor.py
@@ -4,7 +4,7 @@ from app.classes.room import Room
 
 class TestSensor:
     def test_from_dict(self):
-        data = {'id': 'sensor1', 'rooms': ['room1', 'room2']}
+        data = {'id': 'sensor1', 'rooms': ['room1', 'room2'], 'longitude': 10.0, 'latitude': 20.0}
         sensor = Sensor.from_dict(data)
         assert sensor.id == 'sensor1'
         assert sensor.room_ids == ['room1', 'room2']
@@ -12,7 +12,7 @@ class TestSensor:
         assert sensor.rooms == []
 
     def test_attach_rooms_with_valid_and_invalid_ids(self):
-        sensor = Sensor('sensor1', ['room1', 'roomX'])
+        sensor = Sensor('sensor1', ['room1', 'roomX'], 10.0, 20.0)
         room1 = Room('room1', 'Room A', 5, 100, 200)
         room_mapping = {'room1': room1}
         sensor.attach_rooms(room_mapping)

--- a/app/test/classes/test_sensor_graph.py
+++ b/app/test/classes/test_sensor_graph.py
@@ -16,18 +16,18 @@ class TestSensorGraph:
 
         # Create sensors with exactly two rooms each.
         # Sensors 1, 2, and 3 share rooms in a way that forms a connected subgraph.
-        sensor1 = Sensor('sensor1', [])
+        sensor1 = Sensor('sensor1', [], 12.34, 56.78)
         sensor1.rooms = [room1, room2]  # sensor1: room1 and room2
-        sensor2 = Sensor('sensor2', [])
+        sensor2 = Sensor('sensor2', [], 12.34, 56.78)
         sensor2.rooms = [room1, room3]  # sensor2: room1 and room3 (common with sensor1: room1)
-        sensor3 = Sensor('sensor3', [])
+        sensor3 = Sensor('sensor3', [], 12.34, 56.78)
         sensor3.rooms = [
             room2,
             room3,
         ]  # sensor3: room2 and room3 (common with sensor1: room2, sensor2: room3)
 
         # Sensor4 is isolated by having a pair of rooms that no other sensor uses.
-        sensor4 = Sensor('sensor4', [])
+        sensor4 = Sensor('sensor4', [], 12.34, 56.78)
         sensor4.rooms = [room4, room5]
 
         return [sensor1, sensor2, sensor3, sensor4], (room1, room2, room3, room4, room5)
@@ -62,9 +62,9 @@ class TestSensorGraph:
         # Create two sensors sharing exactly the same two rooms.
         room1 = Room('room1', 'Room A', 5, 100, 200)
         room2 = Room('room2', 'Room B', 3, 50, 150)
-        sensor1 = Sensor('sensor1', [])
+        sensor1 = Sensor('sensor1', [], 12.34, 56.78)
         sensor1.rooms = [room1, room2]
-        sensor2 = Sensor('sensor2', [])
+        sensor2 = Sensor('sensor2', [], 12.34, 56.78)
         sensor2.rooms = [room1, room2]
         sensors = [sensor1, sensor2]
         graph_obj = SensorGraph(sensors)
@@ -80,11 +80,11 @@ class TestSensorGraph:
         # Create three sensors that all share the same two rooms.
         room1 = Room('room1', 'Room A', 2, 50, 100)
         room2 = Room('room2', 'Room B', 3, 75, 125)
-        sensor1 = Sensor('sensor1', [])
+        sensor1 = Sensor('sensor1', [], 12.34, 56.78)
         sensor1.rooms = [room1, room2]
-        sensor2 = Sensor('sensor2', [])
+        sensor2 = Sensor('sensor2', [], 12.34, 56.78)
         sensor2.rooms = [room1, room2]
-        sensor3 = Sensor('sensor3', [])
+        sensor3 = Sensor('sensor3', [], 12.34, 56.78)
         sensor3.rooms = [room1, room2]
         sensors = [sensor1, sensor2, sensor3]
         graph_obj = SensorGraph(sensors)
@@ -100,9 +100,9 @@ class TestSensorGraph:
         room2 = Room('room2', 'Room B', 3, 75, 125)
         room3 = Room('room3', 'Room C', 4, 100, 150)
         room4 = Room('room4', 'Room D', 5, 125, 175)
-        sensor1 = Sensor('sensor1', [])
+        sensor1 = Sensor('sensor1', [], 12.34, 56.78)
         sensor1.rooms = [room1, room2]
-        sensor2 = Sensor('sensor2', [])
+        sensor2 = Sensor('sensor2', [], 12.34, 56.78)
         sensor2.rooms = [room3, room4]
         sensors = [sensor1, sensor2]
         graph_obj = SensorGraph(sensors)

--- a/app/test/mock_data/rooms_and_sensors.json
+++ b/app/test/mock_data/rooms_and_sensors.json
@@ -1,1591 +1,1846 @@
 {
   "rooms": [
       {
-        "id": "67d935add6d3ce76bef2c881",
-        "name": "RW1",
-        "crowd_factor": 0.3,
-        "occupants": 2,
-        "area": 50.0
+          "id": "67d935add6d3ce76bef2c881",
+          "name": "RW1",
+          "crowd_factor": 0.3,
+          "occupants": 2,
+          "area": 50.0
       },
       {
-        "id": "67d935add6d3ce76bef2c882",
-        "name": "KAFETERIA",
-        "crowd_factor": 0.3,
-        "occupants": 6,
-        "area": 50.0
+          "id": "67d935add6d3ce76bef2c882",
+          "name": "KAFETERIA",
+          "crowd_factor": 0.3,
+          "occupants": 6,
+          "area": 50.0
       },
       {
-        "id": "67d935add6d3ce76bef2c883",
-        "name": "107",
-        "crowd_factor": 0.3,
-        "occupants": 12,
-        "area": 50.0
+          "id": "67d935add6d3ce76bef2c883",
+          "name": "107",
+          "crowd_factor": 0.3,
+          "occupants": 12,
+          "area": 50.0
       },
       {
-        "id": "67d935add6d3ce76bef2c884",
-        "name": "106",
-        "crowd_factor": 0.3,
-        "occupants": 15,
-        "area": 50.0
+          "id": "67d935add6d3ce76bef2c884",
+          "name": "106",
+          "crowd_factor": 0.3,
+          "occupants": 15,
+          "area": 50.0
       },
       {
-        "id": "67d935add6d3ce76bef2c885",
-        "name": "105",
-        "crowd_factor": 0.3,
-        "occupants": 3,
-        "area": 50.0
+          "id": "67d935add6d3ce76bef2c885",
+          "name": "105",
+          "crowd_factor": 0.3,
+          "occupants": 3,
+          "area": 50.0
       },
       {
-        "id": "67d935add6d3ce76bef2c886",
-        "name": "104",
-        "crowd_factor": 0.3,
-        "occupants": 0,
-        "area": 50.0
+          "id": "67d935add6d3ce76bef2c886",
+          "name": "104",
+          "crowd_factor": 0.3,
+          "occupants": 0,
+          "area": 50.0
       },
       {
-        "id": "67d935add6d3ce76bef2c887",
-        "name": "103",
-        "crowd_factor": 0.3,
-        "occupants": 4,
-        "area": 50.0
+          "id": "67d935add6d3ce76bef2c887",
+          "name": "103",
+          "crowd_factor": 0.3,
+          "occupants": 4,
+          "area": 50.0
       },
       {
-        "id": "67d935add6d3ce76bef2c888",
-        "name": "102",
-        "crowd_factor": 0.3,
-        "occupants": 50,
-        "area": 50.0
+          "id": "67d935add6d3ce76bef2c888",
+          "name": "102",
+          "crowd_factor": 0.3,
+          "occupants": 50,
+          "area": 50.0
       },
       {
-        "id": "67d935add6d3ce76bef2c889",
-        "name": "101",
-        "crowd_factor": 0.3,
-        "occupants": 75,
-        "area": 50.0
+          "id": "67d935add6d3ce76bef2c889",
+          "name": "101",
+          "crowd_factor": 0.3,
+          "occupants": 75,
+          "area": 50.0
       },
       {
-        "id": "67d935add6d3ce76bef2c88a",
-        "name": "HALL",
-        "crowd_factor": 0.3,
-        "occupants": 3,
-        "area": 50.0
+          "id": "67d935add6d3ce76bef2c88a",
+          "name": "HALL",
+          "crowd_factor": 0.3,
+          "occupants": 3,
+          "area": 50.0
       },
       {
-        "id": "67d935add6d3ce76bef2c88b",
-        "name": "109",
-        "crowd_factor": 0.3,
-        "occupants": 5,
-        "area": 50.0
+          "id": "67d935add6d3ce76bef2c88b",
+          "name": "109",
+          "crowd_factor": 0.3,
+          "occupants": 5,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c88c",
-        "name": "108",
-        "crowd_factor": 0.3,
-        "occupants": 12,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c88c",
+          "name": "108",
+          "crowd_factor": 0.3,
+          "occupants": 12,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c88d",
-        "name": "SHOP",
-        "crowd_factor": 0.3,
-        "occupants": 25,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c88d",
+          "name": "SHOP",
+          "crowd_factor": 0.3,
+          "occupants": 25,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c88e",
-        "name": "LW1",
-        "crowd_factor": 0.3,
-        "occupants": 73,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c88e",
+          "name": "LW1",
+          "crowd_factor": 0.3,
+          "occupants": 73,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c88f",
-        "name": "114",
-        "crowd_factor": 0.3,
-        "occupants": 37,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c88f",
+          "name": "114",
+          "crowd_factor": 0.3,
+          "occupants": 37,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c890",
-        "name": "115",
-        "crowd_factor": 0.3,
-        "occupants": 45,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c890",
+          "name": "115",
+          "crowd_factor": 0.3,
+          "occupants": 45,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c891",
-        "name": "117",
-        "crowd_factor": 0.3,
-        "occupants": 4,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c891",
+          "name": "117",
+          "crowd_factor": 0.3,
+          "occupants": 4,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c892",
-        "name": "STAGE",
-        "crowd_factor": 0.3,
-        "occupants": 32,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c892",
+          "name": "STAGE",
+          "crowd_factor": 0.3,
+          "occupants": 32,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c893",
-        "name": "113",
-        "crowd_factor": 0.3,
-        "occupants": 45,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c893",
+          "name": "113",
+          "crowd_factor": 0.3,
+          "occupants": 45,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c894",
-        "name": "AUDITORIUM",
-        "crowd_factor": 0.3,
-        "occupants": 2,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c894",
+          "name": "AUDITORIUM",
+          "crowd_factor": 0.3,
+          "occupants": 2,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c895",
-        "name": "STUDYROOM",
-        "crowd_factor": 0.3,
-        "occupants": 5,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c895",
+          "name": "STUDYROOM",
+          "crowd_factor": 0.3,
+          "occupants": 5,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c896",
-        "name": "201A",
-        "crowd_factor": 0.3,
-        "occupants": 7,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c896",
+          "name": "201A",
+          "crowd_factor": 0.3,
+          "occupants": 7,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c897",
-        "name": "201B",
-        "crowd_factor": 0.3,
-        "occupants": 12,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c897",
+          "name": "201B",
+          "crowd_factor": 0.3,
+          "occupants": 12,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c898",
-        "name": "201C",
-        "crowd_factor": 0.3,
-        "occupants": 45,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c898",
+          "name": "201C",
+          "crowd_factor": 0.3,
+          "occupants": 45,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c899",
-        "name": "201D",
-        "crowd_factor": 0.3,
-        "occupants": 87,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c899",
+          "name": "201D",
+          "crowd_factor": 0.3,
+          "occupants": 87,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c89a",
-        "name": "201E",
-        "crowd_factor": 0.3,
-        "occupants": 45,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c89a",
+          "name": "201E",
+          "crowd_factor": 0.3,
+          "occupants": 45,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c89b",
-        "name": "202",
-        "crowd_factor": 0.3,
-        "occupants": 23,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c89b",
+          "name": "202",
+          "crowd_factor": 0.3,
+          "occupants": 23,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c89c",
-        "name": "203",
-        "crowd_factor": 0.3,
-        "occupants": 32,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c89c",
+          "name": "203",
+          "crowd_factor": 0.3,
+          "occupants": 32,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c89d",
-        "name": "204",
-        "crowd_factor": 0.3,
-        "occupants": 7,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c89d",
+          "name": "204",
+          "crowd_factor": 0.3,
+          "occupants": 7,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c89e",
-        "name": "211B",
-        "crowd_factor": 0.3,
-        "occupants": 0,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c89e",
+          "name": "211B",
+          "crowd_factor": 0.3,
+          "occupants": 0,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c89f",
-        "name": "211A",
-        "crowd_factor": 0.3,
-        "occupants": 9,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c89f",
+          "name": "211A",
+          "crowd_factor": 0.3,
+          "occupants": 9,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c8a0",
-        "name": "210B",
-        "crowd_factor": 0.3,
-        "occupants": 8,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c8a0",
+          "name": "210B",
+          "crowd_factor": 0.3,
+          "occupants": 8,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c8a1",
-        "name": "210A",
-        "crowd_factor": 0.3,
-        "occupants": 5,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c8a1",
+          "name": "210A",
+          "crowd_factor": 0.3,
+          "occupants": 5,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c8a2",
-        "name": "208B",
-        "crowd_factor": 0.3,
-        "occupants": 0,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c8a2",
+          "name": "208B",
+          "crowd_factor": 0.3,
+          "occupants": 0,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c8a3",
-        "name": "209",
-        "crowd_factor": 0.3,
-        "occupants": 3,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c8a3",
+          "name": "209",
+          "crowd_factor": 0.3,
+          "occupants": 3,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c8a4",
-        "name": "208A",
-        "crowd_factor": 0.3,
-        "occupants": 5,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c8a4",
+          "name": "208A",
+          "crowd_factor": 0.3,
+          "occupants": 5,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c8a5",
-        "name": "207",
-        "crowd_factor": 0.3,
-        "occupants": 6,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c8a5",
+          "name": "207",
+          "crowd_factor": 0.3,
+          "occupants": 6,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c8a6",
-        "name": "206",
-        "crowd_factor": 0.3,
-        "occupants": 2,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c8a6",
+          "name": "206",
+          "crowd_factor": 0.3,
+          "occupants": 2,
+          "area": 50.0
       },
       {
-        "id": "67d935aed6d3ce76bef2c8a7",
-        "name": "205",
-        "crowd_factor": 0.3,
-        "occupants": 7,
-        "area": 50.0
+          "id": "67d935aed6d3ce76bef2c8a7",
+          "name": "205",
+          "crowd_factor": 0.3,
+          "occupants": 7,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8a8",
-        "name": "T2",
-        "crowd_factor": 0.3,
-        "occupants": 5,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8a8",
+          "name": "T2",
+          "crowd_factor": 0.3,
+          "occupants": 5,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8a9",
-        "name": "T3",
-        "crowd_factor": 0.3,
-        "occupants": 9,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8a9",
+          "name": "T3",
+          "crowd_factor": 0.3,
+          "occupants": 9,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8aa",
-        "name": "P1",
-        "crowd_factor": 0.3,
-        "occupants": 12,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8aa",
+          "name": "P1",
+          "crowd_factor": 0.3,
+          "occupants": 12,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8ab",
-        "name": "P2",
-        "crowd_factor": 0.3,
-        "occupants": 74,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8ab",
+          "name": "P2",
+          "crowd_factor": 0.3,
+          "occupants": 74,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8ac",
-        "name": "P3",
-        "crowd_factor": 0.3,
-        "occupants": 3,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8ac",
+          "name": "P3",
+          "crowd_factor": 0.3,
+          "occupants": 3,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8ad",
-        "name": "P4",
-        "crowd_factor": 0.3,
-        "occupants": 23,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8ad",
+          "name": "P4",
+          "crowd_factor": 0.3,
+          "occupants": 23,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8ae",
-        "name": "212",
-        "crowd_factor": 0.3,
-        "occupants": 12,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8ae",
+          "name": "212",
+          "crowd_factor": 0.3,
+          "occupants": 12,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8af",
-        "name": "213",
-        "crowd_factor": 0.3,
-        "occupants": 17,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8af",
+          "name": "213",
+          "crowd_factor": 0.3,
+          "occupants": 17,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8b0",
-        "name": "214",
-        "crowd_factor": 0.3,
-        "occupants": 15,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8b0",
+          "name": "214",
+          "crowd_factor": 0.3,
+          "occupants": 15,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8b1",
-        "name": "215",
-        "crowd_factor": 0.3,
-        "occupants": 32,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8b1",
+          "name": "215",
+          "crowd_factor": 0.3,
+          "occupants": 32,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8b2",
-        "name": "216",
-        "crowd_factor": 0.3,
-        "occupants": 19,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8b2",
+          "name": "216",
+          "crowd_factor": 0.3,
+          "occupants": 19,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8b3",
-        "name": "T1",
-        "crowd_factor": 0.3,
-        "occupants": 9,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8b3",
+          "name": "T1",
+          "crowd_factor": 0.3,
+          "occupants": 9,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8b4",
-        "name": "217A",
-        "crowd_factor": 0.3,
-        "occupants": 3,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8b4",
+          "name": "217A",
+          "crowd_factor": 0.3,
+          "occupants": 3,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8b5",
-        "name": "229",
-        "crowd_factor": 0.3,
-        "occupants": 4,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8b5",
+          "name": "229",
+          "crowd_factor": 0.3,
+          "occupants": 4,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8b6",
-        "name": "228",
-        "crowd_factor": 0.3,
-        "occupants": 0,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8b6",
+          "name": "228",
+          "crowd_factor": 0.3,
+          "occupants": 0,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8b7",
-        "name": "227",
-        "crowd_factor": 0.3,
-        "occupants": 1,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8b7",
+          "name": "227",
+          "crowd_factor": 0.3,
+          "occupants": 1,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8b8",
-        "name": "217F",
-        "crowd_factor": 0.3,
-        "occupants": 2,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8b8",
+          "name": "217F",
+          "crowd_factor": 0.3,
+          "occupants": 2,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8b9",
-        "name": "217E",
-        "crowd_factor": 0.3,
-        "occupants": 17,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8b9",
+          "name": "217E",
+          "crowd_factor": 0.3,
+          "occupants": 17,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8ba",
-        "name": "217D",
-        "crowd_factor": 0.3,
-        "occupants": 28,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8ba",
+          "name": "217D",
+          "crowd_factor": 0.3,
+          "occupants": 28,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8bb",
-        "name": "217C",
-        "crowd_factor": 0.3,
-        "occupants": 24,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8bb",
+          "name": "217C",
+          "crowd_factor": 0.3,
+          "occupants": 24,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8bc",
-        "name": "217B",
-        "crowd_factor": 0.3,
-        "occupants": 39,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8bc",
+          "name": "217B",
+          "crowd_factor": 0.3,
+          "occupants": 39,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8bd",
-        "name": "218A",
-        "crowd_factor": 0.3,
-        "occupants": 34,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8bd",
+          "name": "218A",
+          "crowd_factor": 0.3,
+          "occupants": 34,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8be",
-        "name": "218B",
-        "crowd_factor": 0.3,
-        "occupants": 29,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8be",
+          "name": "218B",
+          "crowd_factor": 0.3,
+          "occupants": 29,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8bf",
-        "name": "219",
-        "crowd_factor": 0.3,
-        "occupants": 44,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8bf",
+          "name": "219",
+          "crowd_factor": 0.3,
+          "occupants": 44,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8c0",
-        "name": "220",
-        "crowd_factor": 0.3,
-        "occupants": 74,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8c0",
+          "name": "220",
+          "crowd_factor": 0.3,
+          "occupants": 74,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8c1",
-        "name": "P7",
-        "crowd_factor": 0.3,
-        "occupants": 96,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8c1",
+          "name": "P7",
+          "crowd_factor": 0.3,
+          "occupants": 96,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8c2",
-        "name": "222",
-        "crowd_factor": 0.3,
-        "occupants": 4,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8c2",
+          "name": "222",
+          "crowd_factor": 0.3,
+          "occupants": 4,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8c3",
-        "name": "223",
-        "crowd_factor": 0.3,
-        "occupants": 14,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8c3",
+          "name": "223",
+          "crowd_factor": 0.3,
+          "occupants": 14,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8c4",
-        "name": "224",
-        "crowd_factor": 0.3,
-        "occupants": 16,
-        "area": 50.0
+          "id": "67d935afd6d3ce76bef2c8c4",
+          "name": "224",
+          "crowd_factor": 0.3,
+          "occupants": 16,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8c5",
-        "name": "225",
-        "crowd_factor": 0.3,
-        "occupants": 19,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8c5",
+          "name": "225",
+          "crowd_factor": 0.3,
+          "occupants": 19,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8c6",
-        "name": "221",
-        "crowd_factor": 0.3,
-        "occupants": 22,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8c6",
+          "name": "221",
+          "crowd_factor": 0.3,
+          "occupants": 22,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8c7",
-        "name": "226",
-        "crowd_factor": 0.3,
-        "occupants": 4,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8c7",
+          "name": "226",
+          "crowd_factor": 0.3,
+          "occupants": 4,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8c8",
-        "name": "P5",
-        "crowd_factor": 0.3,
-        "occupants": 17,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8c8",
+          "name": "P5",
+          "crowd_factor": 0.3,
+          "occupants": 17,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8c9",
-        "name": "P8",
-        "crowd_factor": 0.3,
-        "occupants": 29,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8c9",
+          "name": "P8",
+          "crowd_factor": 0.3,
+          "occupants": 29,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8ca",
-        "name": "T7",
-        "crowd_factor": 0.3,
-        "occupants": 16,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8ca",
+          "name": "T7",
+          "crowd_factor": 0.3,
+          "occupants": 16,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8cb",
-        "name": "T6",
-        "crowd_factor": 0.3,
-        "occupants": 2,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8cb",
+          "name": "T6",
+          "crowd_factor": 0.3,
+          "occupants": 2,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8cc",
-        "name": "270B",
-        "crowd_factor": 0.3,
-        "occupants": 3,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8cc",
+          "name": "270B",
+          "crowd_factor": 0.3,
+          "occupants": 3,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8cd",
-        "name": "270A",
-        "crowd_factor": 0.3,
-        "occupants": 4,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8cd",
+          "name": "270A",
+          "crowd_factor": 0.3,
+          "occupants": 4,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8ce",
-        "name": "262",
-        "crowd_factor": 0.3,
-        "occupants": 0,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8ce",
+          "name": "262",
+          "crowd_factor": 0.3,
+          "occupants": 0,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8cf",
-        "name": "261",
-        "crowd_factor": 0.3,
-        "occupants": 1,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8cf",
+          "name": "261",
+          "crowd_factor": 0.3,
+          "occupants": 1,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8d0",
-        "name": "272",
-        "crowd_factor": 0.3,
-        "occupants": 2,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8d0",
+          "name": "272",
+          "crowd_factor": 0.3,
+          "occupants": 2,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8d1",
-        "name": "260",
-        "crowd_factor": 0.3,
-        "occupants": 3,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8d1",
+          "name": "260",
+          "crowd_factor": 0.3,
+          "occupants": 3,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8d2",
-        "name": "P9",
-        "crowd_factor": 0.3,
-        "occupants": 4,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8d2",
+          "name": "P9",
+          "crowd_factor": 0.3,
+          "occupants": 4,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8d3",
-        "name": "269A",
-        "crowd_factor": 0.3,
-        "occupants": 5,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8d3",
+          "name": "269A",
+          "crowd_factor": 0.3,
+          "occupants": 5,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8d4",
-        "name": "269B",
-        "crowd_factor": 0.3,
-        "occupants": 6,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8d4",
+          "name": "269B",
+          "crowd_factor": 0.3,
+          "occupants": 6,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8d5",
-        "name": "263B",
-        "crowd_factor": 0.3,
-        "occupants": 7,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8d5",
+          "name": "263B",
+          "crowd_factor": 0.3,
+          "occupants": 7,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8d6",
-        "name": "263C",
-        "crowd_factor": 0.3,
-        "occupants": 12,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8d6",
+          "name": "263C",
+          "crowd_factor": 0.3,
+          "occupants": 12,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8d7",
-        "name": "263A",
-        "crowd_factor": 0.3,
-        "occupants": 32,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8d7",
+          "name": "263A",
+          "crowd_factor": 0.3,
+          "occupants": 32,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8d8",
-        "name": "P6",
-        "crowd_factor": 0.3,
-        "occupants": 27,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8d8",
+          "name": "P6",
+          "crowd_factor": 0.3,
+          "occupants": 27,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8d9",
-        "name": "P10",
-        "crowd_factor": 0.3,
-        "occupants": 55,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8d9",
+          "name": "P10",
+          "crowd_factor": 0.3,
+          "occupants": 55,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8da",
-        "name": "T5",
-        "crowd_factor": 0.3,
-        "occupants": 6,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8da",
+          "name": "T5",
+          "crowd_factor": 0.3,
+          "occupants": 6,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8db",
-        "name": "T4",
-        "crowd_factor": 0.3,
-        "occupants": 4,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8db",
+          "name": "T4",
+          "crowd_factor": 0.3,
+          "occupants": 4,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8dc",
-        "name": "268A",
-        "crowd_factor": 0.3,
-        "occupants": 3,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8dc",
+          "name": "268A",
+          "crowd_factor": 0.3,
+          "occupants": 3,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8dd",
-        "name": "268B",
-        "crowd_factor": 0.3,
-        "occupants": 8,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8dd",
+          "name": "268B",
+          "crowd_factor": 0.3,
+          "occupants": 8,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8de",
-        "name": "264",
-        "crowd_factor": 0.3,
-        "occupants": 2,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8de",
+          "name": "264",
+          "crowd_factor": 0.3,
+          "occupants": 2,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8df",
-        "name": "264A",
-        "crowd_factor": 0.3,
-        "occupants": 3,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8df",
+          "name": "264A",
+          "crowd_factor": 0.3,
+          "occupants": 3,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8e0",
-        "name": "267",
-        "crowd_factor": 0.3,
-        "occupants": 4,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8e0",
+          "name": "267",
+          "crowd_factor": 0.3,
+          "occupants": 4,
+          "area": 50.0
       },
       {
-        "id": "67d935b0d6d3ce76bef2c8e1",
-        "name": "265",
-        "crowd_factor": 0.3,
-        "occupants": 12,
-        "area": 50.0
+          "id": "67d935b0d6d3ce76bef2c8e1",
+          "name": "265",
+          "crowd_factor": 0.3,
+          "occupants": 12,
+          "area": 50.0
       },
       {
-        "id": "67d935b1d6d3ce76bef2c8e2",
-        "name": "266",
-        "crowd_factor": 0.3,
-        "occupants": 32,
-        "area": 50.0
+          "id": "67d935b1d6d3ce76bef2c8e2",
+          "name": "266",
+          "crowd_factor": 0.3,
+          "occupants": 32,
+          "area": 50.0
       }
-    ],
-    "sensors": [
+  ],
+  "sensors": [
+      {
+          "id": "67d935b1d6d3ce76bef2c8e3",
+          "rooms": [
+              "67d935add6d3ce76bef2c881",
+              "67d935afd6d3ce76bef2c8a8"
+          ],
+          "latitude": 74.39539723500168,
+          "longitude": 60.276405902684616
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8e4",
+          "rooms": [
+              "67d935add6d3ce76bef2c881",
+              "67d935afd6d3ce76bef2c8a9"
+          ],
+          "latitude": 68.68545881737853,
+          "longitude": 46.41453989287689
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8e5",
+          "rooms": [
+              "67d935add6d3ce76bef2c882",
+              "67d935add6d3ce76bef2c881"
+          ],
+          "latitude": 22.19283664024259,
+          "longitude": 46.84782313879598
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8e6",
+          "rooms": [
+              "67d935add6d3ce76bef2c889",
+              "67d935add6d3ce76bef2c881"
+          ],
+          "latitude": 34.88966006318424,
+          "longitude": 54.4802816830776
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8e7",
+          "rooms": [
+              "67d935add6d3ce76bef2c883",
+              "67d935add6d3ce76bef2c881"
+          ],
+          "latitude": 46.42458874023367,
+          "longitude": 31.640330334346945
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8e8",
+          "rooms": [
+              "67d935add6d3ce76bef2c88a",
+              "67d935add6d3ce76bef2c882"
+          ],
+          "latitude": 10.636127342128658,
+          "longitude": 70.96945529130602
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8e9",
+          "rooms": [
+              "67d935add6d3ce76bef2c884",
+              "67d935add6d3ce76bef2c883"
+          ],
+          "latitude": 23.56226279492789,
+          "longitude": 71.66197686881827
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8ea",
+          "rooms": [
+              "67d935add6d3ce76bef2c885",
+              "67d935add6d3ce76bef2c884"
+          ],
+          "latitude": 27.412105036015234,
+          "longitude": 10.072407629021153
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8eb",
+          "rooms": [
+              "67d935add6d3ce76bef2c886",
+              "67d935add6d3ce76bef2c885"
+          ],
+          "latitude": 20.72887780112738,
+          "longitude": 11.730632222236487
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8ec",
+          "rooms": [
+              "67d935add6d3ce76bef2c887",
+              "67d935add6d3ce76bef2c886"
+          ],
+          "latitude": 59.07873088730174,
+          "longitude": 38.00899958346011
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8ed",
+          "rooms": [
+              "67d935add6d3ce76bef2c888",
+              "67d935add6d3ce76bef2c887"
+          ],
+          "latitude": 18.5056596943287,
+          "longitude": 68.8997001588457
+      },
       {
-        "id": "67d935b1d6d3ce76bef2c8e3",
-        "rooms": [
-          "67d935add6d3ce76bef2c881",
-          "67d935afd6d3ce76bef2c8a8"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8e4",
-        "rooms": [
-          "67d935add6d3ce76bef2c881",
-          "67d935afd6d3ce76bef2c8a9"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8e5",
-        "rooms": [
-          "67d935add6d3ce76bef2c882",
-          "67d935add6d3ce76bef2c881"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8e6",
-        "rooms": [
-          "67d935add6d3ce76bef2c889",
-          "67d935add6d3ce76bef2c881"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8e7",
-        "rooms": [
-          "67d935add6d3ce76bef2c883",
-          "67d935add6d3ce76bef2c881"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8e8",
-        "rooms": [
-          "67d935add6d3ce76bef2c88a",
-          "67d935add6d3ce76bef2c882"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8e9",
-        "rooms": [
-          "67d935add6d3ce76bef2c884",
-          "67d935add6d3ce76bef2c883"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8ea",
-        "rooms": [
-          "67d935add6d3ce76bef2c885",
-          "67d935add6d3ce76bef2c884"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8eb",
-        "rooms": [
-          "67d935add6d3ce76bef2c886",
-          "67d935add6d3ce76bef2c885"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8ec",
-        "rooms": [
-          "67d935add6d3ce76bef2c887",
-          "67d935add6d3ce76bef2c886"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8ed",
-        "rooms": [
-          "67d935add6d3ce76bef2c888",
-          "67d935add6d3ce76bef2c887"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8ee",
-        "rooms": [
-          "67d935add6d3ce76bef2c888",
-          "67d935add6d3ce76bef2c88a"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8ef",
-        "rooms": [
-          "67d935add6d3ce76bef2c889",
-          "67d935add6d3ce76bef2c88a"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8f0",
-        "rooms": [
-          "67d935add6d3ce76bef2c88a",
-          "67d935afd6d3ce76bef2c8b3"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8f1",
-        "rooms": [
-          "67d935add6d3ce76bef2c88b",
-          "67d935add6d3ce76bef2c88a"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8f2",
-        "rooms": [
-          "67d935add6d3ce76bef2c88b",
-          "67d935aed6d3ce76bef2c88e"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8f3",
-        "rooms": [
-          "67d935aed6d3ce76bef2c88c",
-          "67d935add6d3ce76bef2c88a"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8f4",
-        "rooms": [
-          "67d935aed6d3ce76bef2c88c",
-          "67d935aed6d3ce76bef2c88e"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8f5",
-        "rooms": [
-          "67d935add6d3ce76bef2c88a",
-          "67d935aed6d3ce76bef2c88d"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8f6",
-        "rooms": [
-          "67d935aed6d3ce76bef2c88e",
-          "67d935aed6d3ce76bef2c88d"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8f7",
-        "rooms": [
-          "67d935aed6d3ce76bef2c88f",
-          "67d935aed6d3ce76bef2c890"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8f8",
-        "rooms": [
-          "67d935aed6d3ce76bef2c893",
-          "67d935aed6d3ce76bef2c890"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8f9",
-        "rooms": [
-          "67d935aed6d3ce76bef2c890",
-          "67d935aed6d3ce76bef2c892"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8fa",
-        "rooms": [
-          "67d935aed6d3ce76bef2c891",
-          "67d935aed6d3ce76bef2c892"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8fb",
-        "rooms": [
-          "67d935aed6d3ce76bef2c893",
-          "67d935aed6d3ce76bef2c892"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8fc",
-        "rooms": [
-          "67d935aed6d3ce76bef2c894",
-          "67d935aed6d3ce76bef2c892"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8fd",
-        "rooms": [
-          "67d935aed6d3ce76bef2c893",
-          "67d935add6d3ce76bef2c88a"
-        ]
-      },
-      {
-        "id": "67d935b1d6d3ce76bef2c8fe",
-        "rooms": [
-          "67d935aed6d3ce76bef2c893",
-          "67d935aed6d3ce76bef2c894"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c8ff",
-        "rooms": [
-          "67d935aed6d3ce76bef2c894",
-          "67d935aed6d3ce76bef2c895"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c900",
-        "rooms": [
-          "67d935aed6d3ce76bef2c895",
-          "67d935b0d6d3ce76bef2c8db"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c901",
-        "rooms": [
-          "67d935aed6d3ce76bef2c893",
-          "67d935aed6d3ce76bef2c895"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c902",
-        "rooms": [
-          "67d935aed6d3ce76bef2c896",
-          "67d935aed6d3ce76bef2c897"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c903",
-        "rooms": [
-          "67d935aed6d3ce76bef2c896",
-          "67d935aed6d3ce76bef2c89e"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c904",
-        "rooms": [
-          "67d935aed6d3ce76bef2c896",
-          "67d935aed6d3ce76bef2c89b"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c905",
-        "rooms": [
-          "67d935aed6d3ce76bef2c896",
-          "67d935afd6d3ce76bef2c8aa"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c906",
-        "rooms": [
-          "67d935aed6d3ce76bef2c897",
-          "67d935aed6d3ce76bef2c898"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c907",
-        "rooms": [
-          "67d935aed6d3ce76bef2c898",
-          "67d935aed6d3ce76bef2c899"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c908",
-        "rooms": [
-          "67d935aed6d3ce76bef2c899",
-          "67d935aed6d3ce76bef2c89a"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c909",
-        "rooms": [
-          "67d935aed6d3ce76bef2c899",
-          "67d935aed6d3ce76bef2c8a3"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c90a",
-        "rooms": [
-          "67d935aed6d3ce76bef2c89a",
-          "67d935aed6d3ce76bef2c89d"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c90b",
-        "rooms": [
-          "67d935aed6d3ce76bef2c89b",
-          "67d935aed6d3ce76bef2c89c"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c90c",
-        "rooms": [
-          "67d935aed6d3ce76bef2c89b",
-          "67d935afd6d3ce76bef2c8aa"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c90d",
-        "rooms": [
-          "67d935aed6d3ce76bef2c89c",
-          "67d935aed6d3ce76bef2c89d"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c90e",
-        "rooms": [
-          "67d935aed6d3ce76bef2c89d",
-          "67d935aed6d3ce76bef2c8a7"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c90f",
-        "rooms": [
-          "67d935aed6d3ce76bef2c89f",
-          "67d935aed6d3ce76bef2c89e"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c910",
-        "rooms": [
-          "67d935aed6d3ce76bef2c8a0",
-          "67d935aed6d3ce76bef2c89f"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c911",
-        "rooms": [
-          "67d935aed6d3ce76bef2c8a1",
-          "67d935aed6d3ce76bef2c8a0"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c912",
-        "rooms": [
-          "67d935aed6d3ce76bef2c8a3",
-          "67d935aed6d3ce76bef2c8a1"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c913",
-        "rooms": [
-          "67d935aed6d3ce76bef2c8a2",
-          "67d935aed6d3ce76bef2c8a3"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c914",
-        "rooms": [
-          "67d935aed6d3ce76bef2c8a4",
-          "67d935aed6d3ce76bef2c8a2"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c915",
-        "rooms": [
-          "67d935aed6d3ce76bef2c8a7",
-          "67d935aed6d3ce76bef2c8a2"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c916",
-        "rooms": [
-          "67d935aed6d3ce76bef2c8a5",
-          "67d935aed6d3ce76bef2c8a4"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c917",
-        "rooms": [
-          "67d935aed6d3ce76bef2c8a6",
-          "67d935aed6d3ce76bef2c8a5"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c918",
-        "rooms": [
-          "67d935aed6d3ce76bef2c8a5",
-          "67d935afd6d3ce76bef2c8a8"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c919",
-        "rooms": [
-          "67d935aed6d3ce76bef2c8a5",
-          "67d935afd6d3ce76bef2c8a9"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c91a",
-        "rooms": [
-          "67d935aed6d3ce76bef2c8a7",
-          "67d935aed6d3ce76bef2c8a6"
-        ]
-      },
-      {
-        "id": "67d935b2d6d3ce76bef2c91b",
-        "rooms": [
-          "67d935aed6d3ce76bef2c8a7",
-          "67d935aed6d3ce76bef2c8a4"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c91c",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8ae",
-          "67d935afd6d3ce76bef2c8aa"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c91d",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8aa",
-          "67d935afd6d3ce76bef2c8ab"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c91e",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8aa",
-          "67d935afd6d3ce76bef2c8ac"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c91f",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8ab",
-          "67d935afd6d3ce76bef2c8ad"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c920",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8ac",
-          "67d935afd6d3ce76bef2c8ad"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c921",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8b5",
-          "67d935afd6d3ce76bef2c8ad"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c922",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8b4",
-          "67d935afd6d3ce76bef2c8ad"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c923",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8b2",
-          "67d935afd6d3ce76bef2c8ad"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c924",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8ae",
-          "67d935afd6d3ce76bef2c8af"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c925",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8af",
-          "67d935afd6d3ce76bef2c8b0"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c926",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8b0",
-          "67d935afd6d3ce76bef2c8b1"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c927",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8b1",
-          "67d935afd6d3ce76bef2c8b2"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c928",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8aa",
-          "67d935afd6d3ce76bef2c8b3"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c929",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8b4",
-          "67d935afd6d3ce76bef2c8bd"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c92a",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8b4",
-          "67d935afd6d3ce76bef2c8b5"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c92b",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8b4",
-          "67d935afd6d3ce76bef2c8bc"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c92c",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8b6",
-          "67d935afd6d3ce76bef2c8b5"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c92d",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8b7",
-          "67d935afd6d3ce76bef2c8b6"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c92e",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8b8",
-          "67d935afd6d3ce76bef2c8b7"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c92f",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8c6",
-          "67d935afd6d3ce76bef2c8b7"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c930",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8b9",
-          "67d935afd6d3ce76bef2c8b8"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c931",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8b8",
-          "67d935afd6d3ce76bef2c8c0"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c932",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8ba",
-          "67d935afd6d3ce76bef2c8b9"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c933",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8bb",
-          "67d935afd6d3ce76bef2c8ba"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c934",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8bc",
-          "67d935afd6d3ce76bef2c8bb"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c935",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8bd",
-          "67d935afd6d3ce76bef2c8be"
-        ]
-      },
-      {
-        "id": "67d935b3d6d3ce76bef2c936",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8be",
-          "67d935afd6d3ce76bef2c8bf"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c937",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8bf",
-          "67d935afd6d3ce76bef2c8c0"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c938",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8c0",
-          "67d935afd6d3ce76bef2c8c1"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c939",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8c6",
-          "67d935afd6d3ce76bef2c8c1"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c93a",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8c2",
-          "67d935afd6d3ce76bef2c8c1"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c93b",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8c2",
-          "67d935afd6d3ce76bef2c8c3"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c93c",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8c6",
-          "67d935afd6d3ce76bef2c8c3"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c93d",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8c3",
-          "67d935afd6d3ce76bef2c8c4"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c93e",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8c4",
-          "67d935b0d6d3ce76bef2c8c5"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c93f",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8c5",
-          "67d935b0d6d3ce76bef2c8c7"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c940",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8c6",
-          "67d935b0d6d3ce76bef2c8c5"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c941",
-        "rooms": [
-          "67d935afd6d3ce76bef2c8bd",
-          "67d935b0d6d3ce76bef2c8c8"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c942",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8c8",
-          "67d935b0d6d3ce76bef2c8c9"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c943",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8c8",
-          "67d935b0d6d3ce76bef2c8d2"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c944",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8cc",
-          "67d935b0d6d3ce76bef2c8c9"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c945",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8cd",
-          "67d935b0d6d3ce76bef2c8c9"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c946",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8ce",
-          "67d935b0d6d3ce76bef2c8c9"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c947",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8d0",
-          "67d935b0d6d3ce76bef2c8c9"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c948",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8cf",
-          "67d935b0d6d3ce76bef2c8c9"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c949",
-        "rooms": [
-          "67d935aed6d3ce76bef2c890",
-          "67d935b0d6d3ce76bef2c8ca"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c94a",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8c9",
-          "67d935b0d6d3ce76bef2c8ca"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c94b",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8c8",
-          "67d935b0d6d3ce76bef2c8cb"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c94c",
-        "rooms": [
-          "67d935aed6d3ce76bef2c893",
-          "67d935b0d6d3ce76bef2c8cb"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c94d",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8cf",
-          "67d935b0d6d3ce76bef2c8ce"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c94e",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8d1",
-          "67d935b0d6d3ce76bef2c8d0"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c94f",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8d3",
-          "67d935b0d6d3ce76bef2c8d2"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c950",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8d4",
-          "67d935b0d6d3ce76bef2c8d2"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c951",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8d5",
-          "67d935b0d6d3ce76bef2c8d2"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c952",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8d6",
-          "67d935b0d6d3ce76bef2c8d2"
-        ]
-      },
-      {
-        "id": "67d935b4d6d3ce76bef2c953",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8d8",
-          "67d935b0d6d3ce76bef2c8d2"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c954",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8d5",
-          "67d935b0d6d3ce76bef2c8d6"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c955",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8d7",
-          "67d935b0d6d3ce76bef2c8d6"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c956",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8d9",
-          "67d935b0d6d3ce76bef2c8d8"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c957",
-        "rooms": [
-          "67d935aed6d3ce76bef2c89e",
-          "67d935b0d6d3ce76bef2c8d8"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c958",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8dc",
-          "67d935b0d6d3ce76bef2c8d9"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c959",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8dd",
-          "67d935b0d6d3ce76bef2c8d9"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c95a",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8de",
-          "67d935b0d6d3ce76bef2c8d9"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c95b",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8e0",
-          "67d935b0d6d3ce76bef2c8d9"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c95c",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8e1",
-          "67d935b0d6d3ce76bef2c8d9"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c95d",
-        "rooms": [
-          "67d935b1d6d3ce76bef2c8e2",
-          "67d935b0d6d3ce76bef2c8d9"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c95e",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8d8",
-          "67d935b0d6d3ce76bef2c8da"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c95f",
-        "rooms": [
-          "67d935aed6d3ce76bef2c893",
-          "67d935b0d6d3ce76bef2c8da"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c960",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8d9",
-          "67d935b0d6d3ce76bef2c8db"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c961",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8de",
-          "67d935b0d6d3ce76bef2c8df"
-        ]
-      },
-      {
-        "id": "67d935b5d6d3ce76bef2c962",
-        "rooms": [
-          "67d935b0d6d3ce76bef2c8e1",
-          "67d935b1d6d3ce76bef2c8e2"
-        ]
+          "id": "67d935b1d6d3ce76bef2c8ee",
+          "rooms": [
+              "67d935add6d3ce76bef2c888",
+              "67d935add6d3ce76bef2c88a"
+          ],
+          "latitude": 11.689482820451282,
+          "longitude": 29.48600423892569
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8ef",
+          "rooms": [
+              "67d935add6d3ce76bef2c889",
+              "67d935add6d3ce76bef2c88a"
+          ],
+          "latitude": 32.67969167105791,
+          "longitude": 45.95692103008041
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8f0",
+          "rooms": [
+              "67d935add6d3ce76bef2c88a",
+              "67d935afd6d3ce76bef2c8b3"
+          ],
+          "latitude": 13.354393924491582,
+          "longitude": 37.59215983467645
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8f1",
+          "rooms": [
+              "67d935add6d3ce76bef2c88b",
+              "67d935add6d3ce76bef2c88a"
+          ],
+          "latitude": 26.425696638668622,
+          "longitude": 21.388996186200245
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8f2",
+          "rooms": [
+              "67d935add6d3ce76bef2c88b",
+              "67d935aed6d3ce76bef2c88e"
+          ],
+          "latitude": 29.832952879668788,
+          "longitude": 31.56163148070313
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8f3",
+          "rooms": [
+              "67d935aed6d3ce76bef2c88c",
+              "67d935add6d3ce76bef2c88a"
+          ],
+          "latitude": 10.21614796047703,
+          "longitude": 52.54645039113231
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8f4",
+          "rooms": [
+              "67d935aed6d3ce76bef2c88c",
+              "67d935aed6d3ce76bef2c88e"
+          ],
+          "latitude": 70.44055623641728,
+          "longitude": 37.522859456925744
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8f5",
+          "rooms": [
+              "67d935add6d3ce76bef2c88a",
+              "67d935aed6d3ce76bef2c88d"
+          ],
+          "latitude": 69.91529310655605,
+          "longitude": 73.83311195169951
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8f6",
+          "rooms": [
+              "67d935aed6d3ce76bef2c88e",
+              "67d935aed6d3ce76bef2c88d"
+          ],
+          "latitude": 49.70812327257,
+          "longitude": 22.35184187121149
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8f7",
+          "rooms": [
+              "67d935aed6d3ce76bef2c88f",
+              "67d935aed6d3ce76bef2c890"
+          ],
+          "latitude": 39.09816654782378,
+          "longitude": 36.88452763792615
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8f8",
+          "rooms": [
+              "67d935aed6d3ce76bef2c893",
+              "67d935aed6d3ce76bef2c890"
+          ],
+          "latitude": 75.1087167554598,
+          "longitude": 58.23716877909051
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8f9",
+          "rooms": [
+              "67d935aed6d3ce76bef2c890",
+              "67d935aed6d3ce76bef2c892"
+          ],
+          "latitude": 40.763672448780156,
+          "longitude": 32.89802617636863
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8fa",
+          "rooms": [
+              "67d935aed6d3ce76bef2c891",
+              "67d935aed6d3ce76bef2c892"
+          ],
+          "latitude": 10.895275580412374,
+          "longitude": 19.63210595692754
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8fb",
+          "rooms": [
+              "67d935aed6d3ce76bef2c893",
+              "67d935aed6d3ce76bef2c892"
+          ],
+          "latitude": 70.62923902659912,
+          "longitude": 42.1448775419623
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8fc",
+          "rooms": [
+              "67d935aed6d3ce76bef2c894",
+              "67d935aed6d3ce76bef2c892"
+          ],
+          "latitude": 14.633218404079683,
+          "longitude": 60.899744876189736
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8fd",
+          "rooms": [
+              "67d935aed6d3ce76bef2c893",
+              "67d935add6d3ce76bef2c88a"
+          ],
+          "latitude": 65.54505700970537,
+          "longitude": 18.72668055691952
+      },
+      {
+          "id": "67d935b1d6d3ce76bef2c8fe",
+          "rooms": [
+              "67d935aed6d3ce76bef2c893",
+              "67d935aed6d3ce76bef2c894"
+          ],
+          "latitude": 14.631033406722706,
+          "longitude": 40.29806365173748
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c8ff",
+          "rooms": [
+              "67d935aed6d3ce76bef2c894",
+              "67d935aed6d3ce76bef2c895"
+          ],
+          "latitude": 75.1770467606344,
+          "longitude": 36.37801726745471
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c900",
+          "rooms": [
+              "67d935aed6d3ce76bef2c895",
+              "67d935b0d6d3ce76bef2c8db"
+          ],
+          "latitude": 22.211064543878468,
+          "longitude": 54.68254900196879
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c901",
+          "rooms": [
+              "67d935aed6d3ce76bef2c893",
+              "67d935aed6d3ce76bef2c895"
+          ],
+          "latitude": 32.400327516603014,
+          "longitude": 70.01394713893703
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c902",
+          "rooms": [
+              "67d935aed6d3ce76bef2c896",
+              "67d935aed6d3ce76bef2c897"
+          ],
+          "latitude": 60.793768121850086,
+          "longitude": 40.52065236788043
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c903",
+          "rooms": [
+              "67d935aed6d3ce76bef2c896",
+              "67d935aed6d3ce76bef2c89e"
+          ],
+          "latitude": 68.97377575939785,
+          "longitude": 65.90925302982896
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c904",
+          "rooms": [
+              "67d935aed6d3ce76bef2c896",
+              "67d935aed6d3ce76bef2c89b"
+          ],
+          "latitude": 12.076281358331078,
+          "longitude": 26.650281553527154
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c905",
+          "rooms": [
+              "67d935aed6d3ce76bef2c896",
+              "67d935afd6d3ce76bef2c8aa"
+          ],
+          "latitude": 41.84112810760831,
+          "longitude": 21.700682481369626
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c906",
+          "rooms": [
+              "67d935aed6d3ce76bef2c897",
+              "67d935aed6d3ce76bef2c898"
+          ],
+          "latitude": 55.96072236529015,
+          "longitude": 66.17789950880265
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c907",
+          "rooms": [
+              "67d935aed6d3ce76bef2c898",
+              "67d935aed6d3ce76bef2c899"
+          ],
+          "latitude": 55.743773005650596,
+          "longitude": 72.87952446563636
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c908",
+          "rooms": [
+              "67d935aed6d3ce76bef2c899",
+              "67d935aed6d3ce76bef2c89a"
+          ],
+          "latitude": 36.14478131411286,
+          "longitude": 35.690211091946885
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c909",
+          "rooms": [
+              "67d935aed6d3ce76bef2c899",
+              "67d935aed6d3ce76bef2c8a3"
+          ],
+          "latitude": 25.223737508218576,
+          "longitude": 64.10955480673803
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c90a",
+          "rooms": [
+              "67d935aed6d3ce76bef2c89a",
+              "67d935aed6d3ce76bef2c89d"
+          ],
+          "latitude": 78.30444616996996,
+          "longitude": 14.178414057726243
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c90b",
+          "rooms": [
+              "67d935aed6d3ce76bef2c89b",
+              "67d935aed6d3ce76bef2c89c"
+          ],
+          "latitude": 11.120931035679703,
+          "longitude": 60.97725222460155
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c90c",
+          "rooms": [
+              "67d935aed6d3ce76bef2c89b",
+              "67d935afd6d3ce76bef2c8aa"
+          ],
+          "latitude": 52.42563233347471,
+          "longitude": 41.83249746651769
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c90d",
+          "rooms": [
+              "67d935aed6d3ce76bef2c89c",
+              "67d935aed6d3ce76bef2c89d"
+          ],
+          "latitude": 70.39976640010137,
+          "longitude": 12.842775336079292
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c90e",
+          "rooms": [
+              "67d935aed6d3ce76bef2c89d",
+              "67d935aed6d3ce76bef2c8a7"
+          ],
+          "latitude": 55.9042166412213,
+          "longitude": 11.731758715009708
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c90f",
+          "rooms": [
+              "67d935aed6d3ce76bef2c89f",
+              "67d935aed6d3ce76bef2c89e"
+          ],
+          "latitude": 37.66565279787585,
+          "longitude": 64.98619867320264
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c910",
+          "rooms": [
+              "67d935aed6d3ce76bef2c8a0",
+              "67d935aed6d3ce76bef2c89f"
+          ],
+          "latitude": 22.085769082591554,
+          "longitude": 65.07374742200801
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c911",
+          "rooms": [
+              "67d935aed6d3ce76bef2c8a1",
+              "67d935aed6d3ce76bef2c8a0"
+          ],
+          "latitude": 51.81918028144642,
+          "longitude": 76.15199343594209
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c912",
+          "rooms": [
+              "67d935aed6d3ce76bef2c8a3",
+              "67d935aed6d3ce76bef2c8a1"
+          ],
+          "latitude": 19.66784648845495,
+          "longitude": 51.89217670142682
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c913",
+          "rooms": [
+              "67d935aed6d3ce76bef2c8a2",
+              "67d935aed6d3ce76bef2c8a3"
+          ],
+          "latitude": 43.34302060706607,
+          "longitude": 63.51148469073129
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c914",
+          "rooms": [
+              "67d935aed6d3ce76bef2c8a4",
+              "67d935aed6d3ce76bef2c8a2"
+          ],
+          "latitude": 73.45037204644227,
+          "longitude": 24.673221908580935
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c915",
+          "rooms": [
+              "67d935aed6d3ce76bef2c8a7",
+              "67d935aed6d3ce76bef2c8a2"
+          ],
+          "latitude": 28.562139612393395,
+          "longitude": 23.87024534989895
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c916",
+          "rooms": [
+              "67d935aed6d3ce76bef2c8a5",
+              "67d935aed6d3ce76bef2c8a4"
+          ],
+          "latitude": 38.68646548594513,
+          "longitude": 72.52109979398482
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c917",
+          "rooms": [
+              "67d935aed6d3ce76bef2c8a6",
+              "67d935aed6d3ce76bef2c8a5"
+          ],
+          "latitude": 11.085393847679429,
+          "longitude": 47.26469607586882
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c918",
+          "rooms": [
+              "67d935aed6d3ce76bef2c8a5",
+              "67d935afd6d3ce76bef2c8a8"
+          ],
+          "latitude": 39.32308537640655,
+          "longitude": 42.35749549345419
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c919",
+          "rooms": [
+              "67d935aed6d3ce76bef2c8a5",
+              "67d935afd6d3ce76bef2c8a9"
+          ],
+          "latitude": 26.90177374848724,
+          "longitude": 50.09529769132648
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c91a",
+          "rooms": [
+              "67d935aed6d3ce76bef2c8a7",
+              "67d935aed6d3ce76bef2c8a6"
+          ],
+          "latitude": 45.36549231606291,
+          "longitude": 79.94685482621384
+      },
+      {
+          "id": "67d935b2d6d3ce76bef2c91b",
+          "rooms": [
+              "67d935aed6d3ce76bef2c8a7",
+              "67d935aed6d3ce76bef2c8a4"
+          ],
+          "latitude": 40.81537669911174,
+          "longitude": 32.81376267424582
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c91c",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8ae",
+              "67d935afd6d3ce76bef2c8aa"
+          ],
+          "latitude": 38.84007857831922,
+          "longitude": 78.88909531085112
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c91d",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8aa",
+              "67d935afd6d3ce76bef2c8ab"
+          ],
+          "latitude": 23.309427377322972,
+          "longitude": 29.2152797279454
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c91e",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8aa",
+              "67d935afd6d3ce76bef2c8ac"
+          ],
+          "latitude": 62.9894482057101,
+          "longitude": 24.590631142165822
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c91f",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8ab",
+              "67d935afd6d3ce76bef2c8ad"
+          ],
+          "latitude": 30.054543625994356,
+          "longitude": 60.32411678948131
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c920",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8ac",
+              "67d935afd6d3ce76bef2c8ad"
+          ],
+          "latitude": 58.29131522886081,
+          "longitude": 77.86437357401852
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c921",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8b5",
+              "67d935afd6d3ce76bef2c8ad"
+          ],
+          "latitude": 52.90536526718712,
+          "longitude": 78.35875701544319
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c922",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8b4",
+              "67d935afd6d3ce76bef2c8ad"
+          ],
+          "latitude": 52.10536188262728,
+          "longitude": 63.99264615611843
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c923",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8b2",
+              "67d935afd6d3ce76bef2c8ad"
+          ],
+          "latitude": 27.457931293311294,
+          "longitude": 27.26301649398104
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c924",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8ae",
+              "67d935afd6d3ce76bef2c8af"
+          ],
+          "latitude": 36.01543060802979,
+          "longitude": 14.09901739434643
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c925",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8af",
+              "67d935afd6d3ce76bef2c8b0"
+          ],
+          "latitude": 62.207519848167756,
+          "longitude": 58.44550612901598
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c926",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8b0",
+              "67d935afd6d3ce76bef2c8b1"
+          ],
+          "latitude": 39.93844758167833,
+          "longitude": 75.48582567903242
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c927",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8b1",
+              "67d935afd6d3ce76bef2c8b2"
+          ],
+          "latitude": 30.13312979568816,
+          "longitude": 50.8251035031783
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c928",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8aa",
+              "67d935afd6d3ce76bef2c8b3"
+          ],
+          "latitude": 27.624785250220025,
+          "longitude": 10.966504181767156
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c929",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8b4",
+              "67d935afd6d3ce76bef2c8bd"
+          ],
+          "latitude": 23.183129132184114,
+          "longitude": 50.65603020710481
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c92a",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8b4",
+              "67d935afd6d3ce76bef2c8b5"
+          ],
+          "latitude": 39.57619564177563,
+          "longitude": 16.768615094262877
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c92b",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8b4",
+              "67d935afd6d3ce76bef2c8bc"
+          ],
+          "latitude": 61.403782239168294,
+          "longitude": 78.38840127683525
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c92c",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8b6",
+              "67d935afd6d3ce76bef2c8b5"
+          ],
+          "latitude": 62.12632894480708,
+          "longitude": 38.65960203654285
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c92d",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8b7",
+              "67d935afd6d3ce76bef2c8b6"
+          ],
+          "latitude": 17.951372597605914,
+          "longitude": 39.008553899794535
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c92e",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8b8",
+              "67d935afd6d3ce76bef2c8b7"
+          ],
+          "latitude": 56.589377525700165,
+          "longitude": 47.11097586041428
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c92f",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8c6",
+              "67d935afd6d3ce76bef2c8b7"
+          ],
+          "latitude": 79.19320288899617,
+          "longitude": 33.388143987978424
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c930",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8b9",
+              "67d935afd6d3ce76bef2c8b8"
+          ],
+          "latitude": 13.455603194488504,
+          "longitude": 46.5220195746586
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c931",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8b8",
+              "67d935afd6d3ce76bef2c8c0"
+          ],
+          "latitude": 17.283706580030582,
+          "longitude": 29.62838676836647
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c932",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8ba",
+              "67d935afd6d3ce76bef2c8b9"
+          ],
+          "latitude": 58.51651747163511,
+          "longitude": 26.824435743113042
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c933",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8bb",
+              "67d935afd6d3ce76bef2c8ba"
+          ],
+          "latitude": 38.12551710398678,
+          "longitude": 69.25390643394985
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c934",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8bc",
+              "67d935afd6d3ce76bef2c8bb"
+          ],
+          "latitude": 28.310338570801918,
+          "longitude": 43.91339295235312
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c935",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8bd",
+              "67d935afd6d3ce76bef2c8be"
+          ],
+          "latitude": 73.31245125612449,
+          "longitude": 13.019001905518431
+      },
+      {
+          "id": "67d935b3d6d3ce76bef2c936",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8be",
+              "67d935afd6d3ce76bef2c8bf"
+          ],
+          "latitude": 50.2591447530422,
+          "longitude": 43.96187666332058
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c937",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8bf",
+              "67d935afd6d3ce76bef2c8c0"
+          ],
+          "latitude": 45.48664598989407,
+          "longitude": 57.76910426881177
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c938",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8c0",
+              "67d935afd6d3ce76bef2c8c1"
+          ],
+          "latitude": 73.3681866925497,
+          "longitude": 13.396319388433085
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c939",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8c6",
+              "67d935afd6d3ce76bef2c8c1"
+          ],
+          "latitude": 17.299045376368518,
+          "longitude": 38.46312520209871
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c93a",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8c2",
+              "67d935afd6d3ce76bef2c8c1"
+          ],
+          "latitude": 73.66896772424207,
+          "longitude": 32.37767994800265
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c93b",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8c2",
+              "67d935afd6d3ce76bef2c8c3"
+          ],
+          "latitude": 41.842944572918356,
+          "longitude": 59.99262543804311
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c93c",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8c6",
+              "67d935afd6d3ce76bef2c8c3"
+          ],
+          "latitude": 70.57922739672182,
+          "longitude": 14.398684634346383
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c93d",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8c3",
+              "67d935afd6d3ce76bef2c8c4"
+          ],
+          "latitude": 54.83223477293463,
+          "longitude": 21.669151638621997
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c93e",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8c4",
+              "67d935b0d6d3ce76bef2c8c5"
+          ],
+          "latitude": 70.24489966753644,
+          "longitude": 42.191838718670574
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c93f",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8c5",
+              "67d935b0d6d3ce76bef2c8c7"
+          ],
+          "latitude": 63.5119994597458,
+          "longitude": 62.328937379153324
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c940",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8c6",
+              "67d935b0d6d3ce76bef2c8c5"
+          ],
+          "latitude": 79.14875810886764,
+          "longitude": 28.249040212155272
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c941",
+          "rooms": [
+              "67d935afd6d3ce76bef2c8bd",
+              "67d935b0d6d3ce76bef2c8c8"
+          ],
+          "latitude": 64.84898899746078,
+          "longitude": 66.1365853839815
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c942",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8c8",
+              "67d935b0d6d3ce76bef2c8c9"
+          ],
+          "latitude": 38.86394508167596,
+          "longitude": 50.1071021177377
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c943",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8c8",
+              "67d935b0d6d3ce76bef2c8d2"
+          ],
+          "latitude": 53.39284005074452,
+          "longitude": 54.70014977771044
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c944",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8cc",
+              "67d935b0d6d3ce76bef2c8c9"
+          ],
+          "latitude": 73.21250050874545,
+          "longitude": 75.52202641601677
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c945",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8cd",
+              "67d935b0d6d3ce76bef2c8c9"
+          ],
+          "latitude": 51.683528837325085,
+          "longitude": 79.18705036677495
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c946",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8ce",
+              "67d935b0d6d3ce76bef2c8c9"
+          ],
+          "latitude": 37.47959418211717,
+          "longitude": 33.83133459575928
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c947",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8d0",
+              "67d935b0d6d3ce76bef2c8c9"
+          ],
+          "latitude": 35.87745477411507,
+          "longitude": 54.494164247907065
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c948",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8cf",
+              "67d935b0d6d3ce76bef2c8c9"
+          ],
+          "latitude": 22.653913443849945,
+          "longitude": 22.908411836468062
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c949",
+          "rooms": [
+              "67d935aed6d3ce76bef2c890",
+              "67d935b0d6d3ce76bef2c8ca"
+          ],
+          "latitude": 62.48452013631905,
+          "longitude": 50.852784434997794
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c94a",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8c9",
+              "67d935b0d6d3ce76bef2c8ca"
+          ],
+          "latitude": 66.95949056970761,
+          "longitude": 54.984835177829424
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c94b",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8c8",
+              "67d935b0d6d3ce76bef2c8cb"
+          ],
+          "latitude": 22.639303769309223,
+          "longitude": 28.637309176684607
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c94c",
+          "rooms": [
+              "67d935aed6d3ce76bef2c893",
+              "67d935b0d6d3ce76bef2c8cb"
+          ],
+          "latitude": 17.882935231668295,
+          "longitude": 28.767932653266573
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c94d",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8cf",
+              "67d935b0d6d3ce76bef2c8ce"
+          ],
+          "latitude": 21.474645088270993,
+          "longitude": 13.010162299051302
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c94e",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8d1",
+              "67d935b0d6d3ce76bef2c8d0"
+          ],
+          "latitude": 67.77697751829533,
+          "longitude": 72.09181446761248
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c94f",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8d3",
+              "67d935b0d6d3ce76bef2c8d2"
+          ],
+          "latitude": 63.622423609592985,
+          "longitude": 75.59650890256935
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c950",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8d4",
+              "67d935b0d6d3ce76bef2c8d2"
+          ],
+          "latitude": 24.291190741620373,
+          "longitude": 47.76436903925618
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c951",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8d5",
+              "67d935b0d6d3ce76bef2c8d2"
+          ],
+          "latitude": 40.31775387728764,
+          "longitude": 55.75923658794434
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c952",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8d6",
+              "67d935b0d6d3ce76bef2c8d2"
+          ],
+          "latitude": 79.31042048664666,
+          "longitude": 25.585837425268004
+      },
+      {
+          "id": "67d935b4d6d3ce76bef2c953",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8d8",
+              "67d935b0d6d3ce76bef2c8d2"
+          ],
+          "latitude": 16.642287452265062,
+          "longitude": 48.29346433667992
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c954",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8d5",
+              "67d935b0d6d3ce76bef2c8d6"
+          ],
+          "latitude": 61.61447265835131,
+          "longitude": 22.378872015467934
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c955",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8d7",
+              "67d935b0d6d3ce76bef2c8d6"
+          ],
+          "latitude": 74.98801755771622,
+          "longitude": 75.55725891742125
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c956",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8d9",
+              "67d935b0d6d3ce76bef2c8d8"
+          ],
+          "latitude": 42.17473673727582,
+          "longitude": 23.659931168921137
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c957",
+          "rooms": [
+              "67d935aed6d3ce76bef2c89e",
+              "67d935b0d6d3ce76bef2c8d8"
+          ],
+          "latitude": 47.5208538059112,
+          "longitude": 33.63344895110909
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c958",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8dc",
+              "67d935b0d6d3ce76bef2c8d9"
+          ],
+          "latitude": 61.112766922119285,
+          "longitude": 39.40916210262553
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c959",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8dd",
+              "67d935b0d6d3ce76bef2c8d9"
+          ],
+          "latitude": 75.57600757786676,
+          "longitude": 72.19347015235122
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c95a",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8de",
+              "67d935b0d6d3ce76bef2c8d9"
+          ],
+          "latitude": 42.8210378030866,
+          "longitude": 47.31982729135278
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c95b",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8e0",
+              "67d935b0d6d3ce76bef2c8d9"
+          ],
+          "latitude": 11.967012979288068,
+          "longitude": 47.29615400358129
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c95c",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8e1",
+              "67d935b0d6d3ce76bef2c8d9"
+          ],
+          "latitude": 69.13764933776481,
+          "longitude": 62.63945868106727
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c95d",
+          "rooms": [
+              "67d935b1d6d3ce76bef2c8e2",
+              "67d935b0d6d3ce76bef2c8d9"
+          ],
+          "latitude": 16.18642486456418,
+          "longitude": 69.14098041320574
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c95e",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8d8",
+              "67d935b0d6d3ce76bef2c8da"
+          ],
+          "latitude": 66.15416047793207,
+          "longitude": 70.80903733911845
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c95f",
+          "rooms": [
+              "67d935aed6d3ce76bef2c893",
+              "67d935b0d6d3ce76bef2c8da"
+          ],
+          "latitude": 61.753614148354124,
+          "longitude": 47.50753491124659
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c960",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8d9",
+              "67d935b0d6d3ce76bef2c8db"
+          ],
+          "latitude": 11.032101366333102,
+          "longitude": 10.857185147851341
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c961",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8de",
+              "67d935b0d6d3ce76bef2c8df"
+          ],
+          "latitude": 20.355786846137036,
+          "longitude": 64.81348685573096
+      },
+      {
+          "id": "67d935b5d6d3ce76bef2c962",
+          "rooms": [
+              "67d935b0d6d3ce76bef2c8e1",
+              "67d935b1d6d3ce76bef2c8e2"
+          ],
+          "latitude": 22.198228684841936,
+          "longitude": 17.729380352688064
       }
-    ],
-    "source_sensor": "67d935b5d6d3ce76bef2c960",
-    "target_sensor": "67d935b5d6d3ce76bef2c961"
-  }
-  
+  ],
+  "source_sensor": "67d935b5d6d3ce76bef2c960",
+  "target_sensor": "67d935b5d6d3ce76bef2c961"
+}

--- a/app/test/mock_data/rooms_and_sensors.json
+++ b/app/test/mock_data/rooms_and_sensors.json
@@ -791,896 +791,1152 @@
             "rooms": [
                 "67d935add6d3ce76bef2c881",
                 "67d935afd6d3ce76bef2c8a8"
-            ]
+            ],
+            "latitude": 74.83430594652332,
+            "longitude": 60.23046513026329
         },
         {
             "id": "67d935b1d6d3ce76bef2c8e4",
             "rooms": [
                 "67d935add6d3ce76bef2c881",
                 "67d935afd6d3ce76bef2c8a9"
-            ]
+            ],
+            "latitude": 11.44847144918591,
+            "longitude": 11.701247390997105
         },
         {
             "id": "67d935b1d6d3ce76bef2c8e5",
             "rooms": [
                 "67d935add6d3ce76bef2c882",
                 "67d935add6d3ce76bef2c881"
-            ]
+            ],
+            "latitude": 63.25643368200438,
+            "longitude": 78.50918711966074
         },
         {
             "id": "67d935b1d6d3ce76bef2c8e6",
             "rooms": [
                 "67d935add6d3ce76bef2c889",
                 "67d935add6d3ce76bef2c881"
-            ]
+            ],
+            "latitude": 44.97588613424094,
+            "longitude": 79.72513840786357
         },
         {
             "id": "67d935b1d6d3ce76bef2c8e7",
             "rooms": [
                 "67d935add6d3ce76bef2c883",
                 "67d935add6d3ce76bef2c881"
-            ]
+            ],
+            "latitude": 33.14663305414036,
+            "longitude": 40.92276097152485
         },
         {
             "id": "67d935b1d6d3ce76bef2c8e8",
             "rooms": [
                 "67d935add6d3ce76bef2c88a",
                 "67d935add6d3ce76bef2c882"
-            ]
+            ],
+            "latitude": 56.49685255055233,
+            "longitude": 77.43733965314345
         },
         {
             "id": "67d935b1d6d3ce76bef2c8e9",
             "rooms": [
                 "67d935add6d3ce76bef2c884",
                 "67d935add6d3ce76bef2c883"
-            ]
+            ],
+            "latitude": 23.8621854675587,
+            "longitude": 16.369509547137667
         },
         {
             "id": "67d935b1d6d3ce76bef2c8ea",
             "rooms": [
                 "67d935add6d3ce76bef2c885",
                 "67d935add6d3ce76bef2c884"
-            ]
+            ],
+            "latitude": 72.87442522121299,
+            "longitude": 61.74727469899295
         },
         {
             "id": "67d935b1d6d3ce76bef2c8eb",
             "rooms": [
                 "67d935add6d3ce76bef2c886",
                 "67d935add6d3ce76bef2c885"
-            ]
+            ],
+            "latitude": 45.93428480026101,
+            "longitude": 53.01855307103911
         },
         {
             "id": "67d935b1d6d3ce76bef2c8ec",
             "rooms": [
                 "67d935add6d3ce76bef2c887",
                 "67d935add6d3ce76bef2c886"
-            ]
+            ],
+            "latitude": 67.63095725977767,
+            "longitude": 32.28598236138496
         },
         {
             "id": "67d935b1d6d3ce76bef2c8ed",
             "rooms": [
                 "67d935add6d3ce76bef2c888",
                 "67d935add6d3ce76bef2c887"
-            ]
+            ],
+            "latitude": 42.64227589111098,
+            "longitude": 56.8878960592352
         },
         {
             "id": "67d935b1d6d3ce76bef2c8ee",
             "rooms": [
                 "67d935add6d3ce76bef2c888",
                 "67d935add6d3ce76bef2c88a"
-            ]
+            ],
+            "latitude": 51.14160578920942,
+            "longitude": 75.21981806330778
         },
         {
             "id": "67d935b1d6d3ce76bef2c8ef",
             "rooms": [
                 "67d935add6d3ce76bef2c889",
                 "67d935add6d3ce76bef2c88a"
-            ]
+            ],
+            "latitude": 62.04303161843357,
+            "longitude": 76.22106731517965
         },
         {
             "id": "67d935b1d6d3ce76bef2c8f0",
             "rooms": [
                 "67d935add6d3ce76bef2c88a",
                 "67d935afd6d3ce76bef2c8b3"
-            ]
+            ],
+            "latitude": 77.7077695964627,
+            "longitude": 58.43619190715721
         },
         {
             "id": "67d935b1d6d3ce76bef2c8f1",
             "rooms": [
                 "67d935add6d3ce76bef2c88b",
                 "67d935add6d3ce76bef2c88a"
-            ]
+            ],
+            "latitude": 20.916074574669835,
+            "longitude": 69.79612468311414
         },
         {
             "id": "67d935b1d6d3ce76bef2c8f2",
             "rooms": [
                 "67d935add6d3ce76bef2c88b",
                 "67d935aed6d3ce76bef2c88e"
-            ]
+            ],
+            "latitude": 63.91464853583392,
+            "longitude": 24.87373437208103
         },
         {
             "id": "67d935b1d6d3ce76bef2c8f3",
             "rooms": [
                 "67d935aed6d3ce76bef2c88c",
                 "67d935add6d3ce76bef2c88a"
-            ]
+            ],
+            "latitude": 60.40527496590818,
+            "longitude": 44.523523530183915
         },
         {
             "id": "67d935b1d6d3ce76bef2c8f4",
             "rooms": [
                 "67d935aed6d3ce76bef2c88c",
                 "67d935aed6d3ce76bef2c88e"
-            ]
+            ],
+            "latitude": 61.44543312568901,
+            "longitude": 64.34541975930827
         },
         {
             "id": "67d935b1d6d3ce76bef2c8f5",
             "rooms": [
                 "67d935add6d3ce76bef2c88a",
                 "67d935aed6d3ce76bef2c88d"
-            ]
+            ],
+            "latitude": 62.7873932552509,
+            "longitude": 24.89611817683759
         },
         {
             "id": "67d935b1d6d3ce76bef2c8f6",
             "rooms": [
                 "67d935aed6d3ce76bef2c88e",
                 "67d935aed6d3ce76bef2c88d"
-            ]
+            ],
+            "latitude": 30.27553127616549,
+            "longitude": 65.35465079223513
         },
         {
             "id": "67d935b1d6d3ce76bef2c8f7",
             "rooms": [
                 "67d935aed6d3ce76bef2c88f",
                 "67d935aed6d3ce76bef2c890"
-            ]
+            ],
+            "latitude": 60.59526742306523,
+            "longitude": 47.321522178974085
         },
         {
             "id": "67d935b1d6d3ce76bef2c8f8",
             "rooms": [
                 "67d935aed6d3ce76bef2c893",
                 "67d935aed6d3ce76bef2c890"
-            ]
+            ],
+            "latitude": 64.48969092662297,
+            "longitude": 41.699782898601
         },
         {
             "id": "67d935b1d6d3ce76bef2c8f9",
             "rooms": [
                 "67d935aed6d3ce76bef2c890",
                 "67d935aed6d3ce76bef2c892"
-            ]
+            ],
+            "latitude": 30.004569072905664,
+            "longitude": 36.362117686287135
         },
         {
             "id": "67d935b1d6d3ce76bef2c8fa",
             "rooms": [
                 "67d935aed6d3ce76bef2c891",
                 "67d935aed6d3ce76bef2c892"
-            ]
+            ],
+            "latitude": 24.642963167826984,
+            "longitude": 71.89770792997385
         },
         {
             "id": "67d935b1d6d3ce76bef2c8fb",
             "rooms": [
                 "67d935aed6d3ce76bef2c893",
                 "67d935aed6d3ce76bef2c892"
-            ]
+            ],
+            "latitude": 22.301446727387777,
+            "longitude": 34.892772629881954
         },
         {
             "id": "67d935b1d6d3ce76bef2c8fc",
             "rooms": [
                 "67d935aed6d3ce76bef2c894",
                 "67d935aed6d3ce76bef2c892"
-            ]
+            ],
+            "latitude": 12.969724174329361,
+            "longitude": 68.71316848105293
         },
         {
             "id": "67d935b1d6d3ce76bef2c8fd",
             "rooms": [
                 "67d935aed6d3ce76bef2c893",
                 "67d935add6d3ce76bef2c88a"
-            ]
+            ],
+            "latitude": 24.169424526472106,
+            "longitude": 20.45941098542403
         },
         {
             "id": "67d935b1d6d3ce76bef2c8fe",
             "rooms": [
                 "67d935aed6d3ce76bef2c893",
                 "67d935aed6d3ce76bef2c894"
-            ]
+            ],
+            "latitude": 75.26874224912515,
+            "longitude": 11.302976416019025
         },
         {
             "id": "67d935b2d6d3ce76bef2c8ff",
             "rooms": [
                 "67d935aed6d3ce76bef2c894",
                 "67d935aed6d3ce76bef2c895"
-            ]
+            ],
+            "latitude": 38.54111749115275,
+            "longitude": 40.34334766951157
         },
         {
             "id": "67d935b2d6d3ce76bef2c900",
             "rooms": [
                 "67d935aed6d3ce76bef2c895",
                 "67d935b0d6d3ce76bef2c8db"
-            ]
+            ],
+            "latitude": 29.166270718387416,
+            "longitude": 41.06272131317476
         },
         {
             "id": "67d935b2d6d3ce76bef2c901",
             "rooms": [
                 "67d935aed6d3ce76bef2c893",
                 "67d935aed6d3ce76bef2c895"
-            ]
+            ],
+            "latitude": 61.696762102422724,
+            "longitude": 62.475685750849834
         },
         {
             "id": "67d935b2d6d3ce76bef2c902",
             "rooms": [
                 "67d935aed6d3ce76bef2c896",
                 "67d935aed6d3ce76bef2c897"
-            ]
+            ],
+            "latitude": 43.15719503005378,
+            "longitude": 52.98867558657682
         },
         {
             "id": "67d935b2d6d3ce76bef2c903",
             "rooms": [
                 "67d935aed6d3ce76bef2c896",
                 "67d935aed6d3ce76bef2c89e"
-            ]
+            ],
+            "latitude": 50.177947784738755,
+            "longitude": 52.412899602614786
         },
         {
             "id": "67d935b2d6d3ce76bef2c904",
             "rooms": [
                 "67d935aed6d3ce76bef2c896",
                 "67d935aed6d3ce76bef2c89b"
-            ]
+            ],
+            "latitude": 24.351026009454767,
+            "longitude": 76.4649033037538
         },
         {
             "id": "67d935b2d6d3ce76bef2c905",
             "rooms": [
                 "67d935aed6d3ce76bef2c896",
                 "67d935afd6d3ce76bef2c8aa"
-            ]
+            ],
+            "latitude": 49.09263528834444,
+            "longitude": 29.5629336667606
         },
         {
             "id": "67d935b2d6d3ce76bef2c906",
             "rooms": [
                 "67d935aed6d3ce76bef2c897",
                 "67d935aed6d3ce76bef2c898"
-            ]
+            ],
+            "latitude": 53.6262556683437,
+            "longitude": 17.11758927007294
         },
         {
             "id": "67d935b2d6d3ce76bef2c907",
             "rooms": [
                 "67d935aed6d3ce76bef2c898",
                 "67d935aed6d3ce76bef2c899"
-            ]
+            ],
+            "latitude": 40.10710560432971,
+            "longitude": 43.00591106330368
         },
         {
             "id": "67d935b2d6d3ce76bef2c908",
             "rooms": [
                 "67d935aed6d3ce76bef2c899",
                 "67d935aed6d3ce76bef2c89a"
-            ]
+            ],
+            "latitude": 53.47065904208061,
+            "longitude": 35.66727708215254
         },
         {
             "id": "67d935b2d6d3ce76bef2c909",
             "rooms": [
                 "67d935aed6d3ce76bef2c899",
                 "67d935aed6d3ce76bef2c8a3"
-            ]
+            ],
+            "latitude": 73.33667062173484,
+            "longitude": 75.25759525989652
         },
         {
             "id": "67d935b2d6d3ce76bef2c90a",
             "rooms": [
                 "67d935aed6d3ce76bef2c89a",
                 "67d935aed6d3ce76bef2c89d"
-            ]
+            ],
+            "latitude": 37.35220933958243,
+            "longitude": 56.54257824278641
         },
         {
             "id": "67d935b2d6d3ce76bef2c90b",
             "rooms": [
                 "67d935aed6d3ce76bef2c89b",
                 "67d935aed6d3ce76bef2c89c"
-            ]
+            ],
+            "latitude": 65.33776081079802,
+            "longitude": 26.83074495369877
         },
         {
             "id": "67d935b2d6d3ce76bef2c90c",
             "rooms": [
                 "67d935aed6d3ce76bef2c89b",
                 "67d935afd6d3ce76bef2c8aa"
-            ]
+            ],
+            "latitude": 75.13220474217677,
+            "longitude": 41.608194502614964
         },
         {
             "id": "67d935b2d6d3ce76bef2c90d",
             "rooms": [
                 "67d935aed6d3ce76bef2c89c",
                 "67d935aed6d3ce76bef2c89d"
-            ]
+            ],
+            "latitude": 34.21993803543363,
+            "longitude": 36.30148224757108
         },
         {
             "id": "67d935b2d6d3ce76bef2c90e",
             "rooms": [
                 "67d935aed6d3ce76bef2c89d",
                 "67d935aed6d3ce76bef2c8a7"
-            ]
+            ],
+            "latitude": 51.44530871791454,
+            "longitude": 15.068402409263303
         },
         {
             "id": "67d935b2d6d3ce76bef2c90f",
             "rooms": [
                 "67d935aed6d3ce76bef2c89f",
                 "67d935aed6d3ce76bef2c89e"
-            ]
+            ],
+            "latitude": 55.043699509540716,
+            "longitude": 71.66192395262479
         },
         {
             "id": "67d935b2d6d3ce76bef2c910",
             "rooms": [
                 "67d935aed6d3ce76bef2c8a0",
                 "67d935aed6d3ce76bef2c89f"
-            ]
+            ],
+            "latitude": 70.53087893058625,
+            "longitude": 79.08832442330224
         },
         {
             "id": "67d935b2d6d3ce76bef2c911",
             "rooms": [
                 "67d935aed6d3ce76bef2c8a1",
                 "67d935aed6d3ce76bef2c8a0"
-            ]
+            ],
+            "latitude": 58.073085802662696,
+            "longitude": 64.22827139095108
         },
         {
             "id": "67d935b2d6d3ce76bef2c912",
             "rooms": [
                 "67d935aed6d3ce76bef2c8a3",
                 "67d935aed6d3ce76bef2c8a1"
-            ]
+            ],
+            "latitude": 55.15563077313062,
+            "longitude": 16.493767375108156
         },
         {
             "id": "67d935b2d6d3ce76bef2c913",
             "rooms": [
                 "67d935aed6d3ce76bef2c8a2",
                 "67d935aed6d3ce76bef2c8a3"
-            ]
+            ],
+            "latitude": 77.32917355304438,
+            "longitude": 67.52445183584032
         },
         {
             "id": "67d935b2d6d3ce76bef2c914",
             "rooms": [
                 "67d935aed6d3ce76bef2c8a4",
                 "67d935aed6d3ce76bef2c8a2"
-            ]
+            ],
+            "latitude": 49.67168837552093,
+            "longitude": 33.339885208618455
         },
         {
             "id": "67d935b2d6d3ce76bef2c915",
             "rooms": [
                 "67d935aed6d3ce76bef2c8a7",
                 "67d935aed6d3ce76bef2c8a2"
-            ]
+            ],
+            "latitude": 73.15260634604306,
+            "longitude": 22.491723668419066
         },
         {
             "id": "67d935b2d6d3ce76bef2c916",
             "rooms": [
                 "67d935aed6d3ce76bef2c8a5",
                 "67d935aed6d3ce76bef2c8a4"
-            ]
+            ],
+            "latitude": 40.003305477630335,
+            "longitude": 77.63589082513765
         },
         {
             "id": "67d935b2d6d3ce76bef2c917",
             "rooms": [
                 "67d935aed6d3ce76bef2c8a6",
                 "67d935aed6d3ce76bef2c8a5"
-            ]
+            ],
+            "latitude": 34.46239249996164,
+            "longitude": 15.348469648186551
         },
         {
             "id": "67d935b2d6d3ce76bef2c918",
             "rooms": [
                 "67d935aed6d3ce76bef2c8a5",
                 "67d935afd6d3ce76bef2c8a8"
-            ]
+            ],
+            "latitude": 60.191338081621794,
+            "longitude": 68.58002180030891
         },
         {
             "id": "67d935b2d6d3ce76bef2c919",
             "rooms": [
                 "67d935aed6d3ce76bef2c8a5",
                 "67d935afd6d3ce76bef2c8a9"
-            ]
+            ],
+            "latitude": 36.865255012928245,
+            "longitude": 46.00757618138332
         },
         {
             "id": "67d935b2d6d3ce76bef2c91a",
             "rooms": [
                 "67d935aed6d3ce76bef2c8a7",
                 "67d935aed6d3ce76bef2c8a6"
-            ]
+            ],
+            "latitude": 70.77722964544611,
+            "longitude": 31.917530005142268
         },
         {
             "id": "67d935b2d6d3ce76bef2c91b",
             "rooms": [
                 "67d935aed6d3ce76bef2c8a7",
                 "67d935aed6d3ce76bef2c8a4"
-            ]
+            ],
+            "latitude": 21.400991090825556,
+            "longitude": 15.239271553378234
         },
         {
             "id": "67d935b3d6d3ce76bef2c91c",
             "rooms": [
                 "67d935afd6d3ce76bef2c8ae",
                 "67d935afd6d3ce76bef2c8aa"
-            ]
+            ],
+            "latitude": 66.84010787506472,
+            "longitude": 15.272182907267277
         },
         {
             "id": "67d935b3d6d3ce76bef2c91d",
             "rooms": [
                 "67d935afd6d3ce76bef2c8aa",
                 "67d935afd6d3ce76bef2c8ab"
-            ]
+            ],
+            "latitude": 61.25688362207111,
+            "longitude": 38.92304028008549
         },
         {
             "id": "67d935b3d6d3ce76bef2c91e",
             "rooms": [
                 "67d935afd6d3ce76bef2c8aa",
                 "67d935afd6d3ce76bef2c8ac"
-            ]
+            ],
+            "latitude": 46.02842523312135,
+            "longitude": 34.06821283904773
         },
         {
             "id": "67d935b3d6d3ce76bef2c91f",
             "rooms": [
                 "67d935afd6d3ce76bef2c8ab",
                 "67d935afd6d3ce76bef2c8ad"
-            ]
+            ],
+            "latitude": 25.19129312171873,
+            "longitude": 10.09896902265163
         },
         {
             "id": "67d935b3d6d3ce76bef2c920",
             "rooms": [
                 "67d935afd6d3ce76bef2c8ac",
                 "67d935afd6d3ce76bef2c8ad"
-            ]
+            ],
+            "latitude": 24.007655855375226,
+            "longitude": 27.047146159964292
         },
         {
             "id": "67d935b3d6d3ce76bef2c921",
             "rooms": [
                 "67d935afd6d3ce76bef2c8b5",
                 "67d935afd6d3ce76bef2c8ad"
-            ]
+            ],
+            "latitude": 37.4991269488913,
+            "longitude": 64.59382731107897
         },
         {
             "id": "67d935b3d6d3ce76bef2c922",
             "rooms": [
                 "67d935afd6d3ce76bef2c8b4",
                 "67d935afd6d3ce76bef2c8ad"
-            ]
+            ],
+            "latitude": 34.08092372523849,
+            "longitude": 10.338795000157544
         },
         {
             "id": "67d935b3d6d3ce76bef2c923",
             "rooms": [
                 "67d935afd6d3ce76bef2c8b2",
                 "67d935afd6d3ce76bef2c8ad"
-            ]
+            ],
+            "latitude": 78.36432912174301,
+            "longitude": 20.86755688499475
         },
         {
             "id": "67d935b3d6d3ce76bef2c924",
             "rooms": [
                 "67d935afd6d3ce76bef2c8ae",
                 "67d935afd6d3ce76bef2c8af"
-            ]
+            ],
+            "latitude": 47.92130450867241,
+            "longitude": 37.629884802078074
         },
         {
             "id": "67d935b3d6d3ce76bef2c925",
             "rooms": [
                 "67d935afd6d3ce76bef2c8af",
                 "67d935afd6d3ce76bef2c8b0"
-            ]
+            ],
+            "latitude": 46.887939054744564,
+            "longitude": 64.3037977757563
         },
         {
             "id": "67d935b3d6d3ce76bef2c926",
             "rooms": [
                 "67d935afd6d3ce76bef2c8b0",
                 "67d935afd6d3ce76bef2c8b1"
-            ]
+            ],
+            "latitude": 20.721540599838534,
+            "longitude": 64.22219403326125
         },
         {
             "id": "67d935b3d6d3ce76bef2c927",
             "rooms": [
                 "67d935afd6d3ce76bef2c8b1",
                 "67d935afd6d3ce76bef2c8b2"
-            ]
+            ],
+            "latitude": 40.21717082731397,
+            "longitude": 65.97865879319669
         },
         {
             "id": "67d935b3d6d3ce76bef2c928",
             "rooms": [
                 "67d935afd6d3ce76bef2c8aa",
                 "67d935afd6d3ce76bef2c8b3"
-            ]
+            ],
+            "latitude": 37.68197805946749,
+            "longitude": 11.505815092124244
         },
         {
             "id": "67d935b3d6d3ce76bef2c929",
             "rooms": [
                 "67d935afd6d3ce76bef2c8b4",
                 "67d935afd6d3ce76bef2c8bd"
-            ]
+            ],
+            "latitude": 57.313372900409675,
+            "longitude": 40.38307776234856
         },
         {
             "id": "67d935b3d6d3ce76bef2c92a",
             "rooms": [
                 "67d935afd6d3ce76bef2c8b4",
                 "67d935afd6d3ce76bef2c8b5"
-            ]
+            ],
+            "latitude": 73.83880403748238,
+            "longitude": 59.779842897828814
         },
         {
             "id": "67d935b3d6d3ce76bef2c92b",
             "rooms": [
                 "67d935afd6d3ce76bef2c8b4",
                 "67d935afd6d3ce76bef2c8bc"
-            ]
+            ],
+            "latitude": 12.779219947822249,
+            "longitude": 79.24695523662146
         },
         {
             "id": "67d935b3d6d3ce76bef2c92c",
             "rooms": [
                 "67d935afd6d3ce76bef2c8b6",
                 "67d935afd6d3ce76bef2c8b5"
-            ]
+            ],
+            "latitude": 28.32926331571139,
+            "longitude": 27.031349510836154
         },
         {
             "id": "67d935b3d6d3ce76bef2c92d",
             "rooms": [
                 "67d935afd6d3ce76bef2c8b7",
                 "67d935afd6d3ce76bef2c8b6"
-            ]
+            ],
+            "latitude": 75.88122379566002,
+            "longitude": 34.780777194789216
         },
         {
             "id": "67d935b3d6d3ce76bef2c92e",
             "rooms": [
                 "67d935afd6d3ce76bef2c8b8",
                 "67d935afd6d3ce76bef2c8b7"
-            ]
+            ],
+            "latitude": 14.803581980465154,
+            "longitude": 71.92901907186302
         },
         {
             "id": "67d935b3d6d3ce76bef2c92f",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8c6",
                 "67d935afd6d3ce76bef2c8b7"
-            ]
+            ],
+            "latitude": 50.684527047688526,
+            "longitude": 60.84537236667158
         },
         {
             "id": "67d935b3d6d3ce76bef2c930",
             "rooms": [
                 "67d935afd6d3ce76bef2c8b9",
                 "67d935afd6d3ce76bef2c8b8"
-            ]
+            ],
+            "latitude": 59.48792647655265,
+            "longitude": 33.910034323958556
         },
         {
             "id": "67d935b3d6d3ce76bef2c931",
             "rooms": [
                 "67d935afd6d3ce76bef2c8b8",
                 "67d935afd6d3ce76bef2c8c0"
-            ]
+            ],
+            "latitude": 21.3314631404267,
+            "longitude": 51.45781102877372
         },
         {
             "id": "67d935b3d6d3ce76bef2c932",
             "rooms": [
                 "67d935afd6d3ce76bef2c8ba",
                 "67d935afd6d3ce76bef2c8b9"
-            ]
+            ],
+            "latitude": 22.66123824424083,
+            "longitude": 14.20989288235753
         },
         {
             "id": "67d935b3d6d3ce76bef2c933",
             "rooms": [
                 "67d935afd6d3ce76bef2c8bb",
                 "67d935afd6d3ce76bef2c8ba"
-            ]
+            ],
+            "latitude": 53.30343564526748,
+            "longitude": 36.06678066029416
         },
         {
             "id": "67d935b3d6d3ce76bef2c934",
             "rooms": [
                 "67d935afd6d3ce76bef2c8bc",
                 "67d935afd6d3ce76bef2c8bb"
-            ]
+            ],
+            "latitude": 19.5280264377472,
+            "longitude": 47.186492942717166
         },
         {
             "id": "67d935b3d6d3ce76bef2c935",
             "rooms": [
                 "67d935afd6d3ce76bef2c8bd",
                 "67d935afd6d3ce76bef2c8be"
-            ]
+            ],
+            "latitude": 17.10910709427426,
+            "longitude": 29.65980948053593
         },
         {
             "id": "67d935b3d6d3ce76bef2c936",
             "rooms": [
                 "67d935afd6d3ce76bef2c8be",
                 "67d935afd6d3ce76bef2c8bf"
-            ]
+            ],
+            "latitude": 50.28439993654972,
+            "longitude": 51.75373729393796
         },
         {
             "id": "67d935b4d6d3ce76bef2c937",
             "rooms": [
                 "67d935afd6d3ce76bef2c8bf",
                 "67d935afd6d3ce76bef2c8c0"
-            ]
+            ],
+            "latitude": 51.73171677920948,
+            "longitude": 33.88995789637876
         },
         {
             "id": "67d935b4d6d3ce76bef2c938",
             "rooms": [
                 "67d935afd6d3ce76bef2c8c0",
                 "67d935afd6d3ce76bef2c8c1"
-            ]
+            ],
+            "latitude": 27.122740809565183,
+            "longitude": 66.32313757307
         },
         {
             "id": "67d935b4d6d3ce76bef2c939",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8c6",
                 "67d935afd6d3ce76bef2c8c1"
-            ]
+            ],
+            "latitude": 16.16035082259174,
+            "longitude": 59.642438100355406
         },
         {
             "id": "67d935b4d6d3ce76bef2c93a",
             "rooms": [
                 "67d935afd6d3ce76bef2c8c2",
                 "67d935afd6d3ce76bef2c8c1"
-            ]
+            ],
+            "latitude": 10.529595306379115,
+            "longitude": 19.79185126741677
         },
         {
             "id": "67d935b4d6d3ce76bef2c93b",
             "rooms": [
                 "67d935afd6d3ce76bef2c8c2",
                 "67d935afd6d3ce76bef2c8c3"
-            ]
+            ],
+            "latitude": 78.23092288077638,
+            "longitude": 33.91185444414431
         },
         {
             "id": "67d935b4d6d3ce76bef2c93c",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8c6",
                 "67d935afd6d3ce76bef2c8c3"
-            ]
+            ],
+            "latitude": 13.381333121143822,
+            "longitude": 19.94413755249763
         },
         {
             "id": "67d935b4d6d3ce76bef2c93d",
             "rooms": [
                 "67d935afd6d3ce76bef2c8c3",
                 "67d935afd6d3ce76bef2c8c4"
-            ]
+            ],
+            "latitude": 50.48957939634512,
+            "longitude": 67.04620433100357
         },
         {
             "id": "67d935b4d6d3ce76bef2c93e",
             "rooms": [
                 "67d935afd6d3ce76bef2c8c4",
                 "67d935b0d6d3ce76bef2c8c5"
-            ]
+            ],
+            "latitude": 69.95424474808655,
+            "longitude": 61.36672331173249
         },
         {
             "id": "67d935b4d6d3ce76bef2c93f",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8c5",
                 "67d935b0d6d3ce76bef2c8c7"
-            ]
+            ],
+            "latitude": 19.55062941573587,
+            "longitude": 23.387740199873804
         },
         {
             "id": "67d935b4d6d3ce76bef2c940",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8c6",
                 "67d935b0d6d3ce76bef2c8c5"
-            ]
+            ],
+            "latitude": 35.75953316897927,
+            "longitude": 28.243535398014153
         },
         {
             "id": "67d935b4d6d3ce76bef2c941",
             "rooms": [
                 "67d935afd6d3ce76bef2c8bd",
                 "67d935b0d6d3ce76bef2c8c8"
-            ]
+            ],
+            "latitude": 34.448484345732155,
+            "longitude": 64.54359640079967
         },
         {
             "id": "67d935b4d6d3ce76bef2c942",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8c8",
                 "67d935b0d6d3ce76bef2c8c9"
-            ]
+            ],
+            "latitude": 30.22670091565439,
+            "longitude": 58.85591625055661
         },
         {
             "id": "67d935b4d6d3ce76bef2c943",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8c8",
                 "67d935b0d6d3ce76bef2c8d2"
-            ]
+            ],
+            "latitude": 51.4004327255261,
+            "longitude": 74.8336144944023
         },
         {
             "id": "67d935b4d6d3ce76bef2c944",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8cc",
                 "67d935b0d6d3ce76bef2c8c9"
-            ]
+            ],
+            "latitude": 24.019847023896933,
+            "longitude": 20.427178295316537
         },
         {
             "id": "67d935b4d6d3ce76bef2c945",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8cd",
                 "67d935b0d6d3ce76bef2c8c9"
-            ]
+            ],
+            "latitude": 18.434572043953438,
+            "longitude": 15.727874647422315
         },
         {
             "id": "67d935b4d6d3ce76bef2c946",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8ce",
                 "67d935b0d6d3ce76bef2c8c9"
-            ]
+            ],
+            "latitude": 20.061986509066813,
+            "longitude": 77.23332923828373
         },
         {
             "id": "67d935b4d6d3ce76bef2c947",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8d0",
                 "67d935b0d6d3ce76bef2c8c9"
-            ]
+            ],
+            "latitude": 39.40701157376124,
+            "longitude": 56.75352719821575
         },
         {
             "id": "67d935b4d6d3ce76bef2c948",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8cf",
                 "67d935b0d6d3ce76bef2c8c9"
-            ]
+            ],
+            "latitude": 30.71314650794406,
+            "longitude": 73.65319878197334
         },
         {
             "id": "67d935b4d6d3ce76bef2c949",
             "rooms": [
                 "67d935aed6d3ce76bef2c890",
                 "67d935b0d6d3ce76bef2c8ca"
-            ]
+            ],
+            "latitude": 74.16269242182065,
+            "longitude": 33.23324548553843
         },
         {
             "id": "67d935b4d6d3ce76bef2c94a",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8c9",
                 "67d935b0d6d3ce76bef2c8ca"
-            ]
+            ],
+            "latitude": 17.663670337366995,
+            "longitude": 77.04410764968375
         },
         {
             "id": "67d935b4d6d3ce76bef2c94b",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8c8",
                 "67d935b0d6d3ce76bef2c8cb"
-            ]
+            ],
+            "latitude": 49.879524798970166,
+            "longitude": 63.111784936644106
         },
         {
             "id": "67d935b4d6d3ce76bef2c94c",
             "rooms": [
                 "67d935aed6d3ce76bef2c893",
                 "67d935b0d6d3ce76bef2c8cb"
-            ]
+            ],
+            "latitude": 34.10448338984773,
+            "longitude": 11.82978614953576
         },
         {
             "id": "67d935b4d6d3ce76bef2c94d",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8cf",
                 "67d935b0d6d3ce76bef2c8ce"
-            ]
+            ],
+            "latitude": 61.75507411125406,
+            "longitude": 40.987195891798855
         },
         {
             "id": "67d935b4d6d3ce76bef2c94e",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8d1",
                 "67d935b0d6d3ce76bef2c8d0"
-            ]
+            ],
+            "latitude": 47.309162475132176,
+            "longitude": 16.056108404089784
         },
         {
             "id": "67d935b4d6d3ce76bef2c94f",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8d3",
                 "67d935b0d6d3ce76bef2c8d2"
-            ]
+            ],
+            "latitude": 38.88796950793725,
+            "longitude": 51.71162490758491
         },
         {
             "id": "67d935b4d6d3ce76bef2c950",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8d4",
                 "67d935b0d6d3ce76bef2c8d2"
-            ]
+            ],
+            "latitude": 77.37070091972903,
+            "longitude": 20.32227224624212
         },
         {
             "id": "67d935b4d6d3ce76bef2c951",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8d5",
                 "67d935b0d6d3ce76bef2c8d2"
-            ]
+            ],
+            "latitude": 59.21064538757568,
+            "longitude": 16.702381115396694
         },
         {
             "id": "67d935b4d6d3ce76bef2c952",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8d6",
                 "67d935b0d6d3ce76bef2c8d2"
-            ]
+            ],
+            "latitude": 68.41734369058616,
+            "longitude": 14.528727743700038
         },
         {
             "id": "67d935b4d6d3ce76bef2c953",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8d8",
                 "67d935b0d6d3ce76bef2c8d2"
-            ]
+            ],
+            "latitude": 30.402024715309174,
+            "longitude": 34.86330675261998
         },
         {
             "id": "67d935b5d6d3ce76bef2c954",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8d5",
                 "67d935b0d6d3ce76bef2c8d6"
-            ]
+            ],
+            "latitude": 49.155581194194156,
+            "longitude": 61.683905508752
         },
         {
             "id": "67d935b5d6d3ce76bef2c955",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8d7",
                 "67d935b0d6d3ce76bef2c8d6"
-            ]
+            ],
+            "latitude": 29.71599215765201,
+            "longitude": 13.975038338890222
         },
         {
             "id": "67d935b5d6d3ce76bef2c956",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8d9",
                 "67d935b0d6d3ce76bef2c8d8"
-            ]
+            ],
+            "latitude": 59.891952380925424,
+            "longitude": 60.54437602773162
         },
         {
             "id": "67d935b5d6d3ce76bef2c957",
             "rooms": [
                 "67d935aed6d3ce76bef2c89e",
                 "67d935b0d6d3ce76bef2c8d8"
-            ]
+            ],
+            "latitude": 52.502048841490996,
+            "longitude": 14.969722305036903
         },
         {
             "id": "67d935b5d6d3ce76bef2c958",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8dc",
                 "67d935b0d6d3ce76bef2c8d9"
-            ]
+            ],
+            "latitude": 30.410423387773257,
+            "longitude": 75.55035523555587
         },
         {
             "id": "67d935b5d6d3ce76bef2c959",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8dd",
                 "67d935b0d6d3ce76bef2c8d9"
-            ]
+            ],
+            "latitude": 70.221113808005,
+            "longitude": 20.503751915901994
         },
         {
             "id": "67d935b5d6d3ce76bef2c95a",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8de",
                 "67d935b0d6d3ce76bef2c8d9"
-            ]
+            ],
+            "latitude": 67.80276018830894,
+            "longitude": 25.297401708592176
         },
         {
             "id": "67d935b5d6d3ce76bef2c95b",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8e0",
                 "67d935b0d6d3ce76bef2c8d9"
-            ]
+            ],
+            "latitude": 72.35763687217128,
+            "longitude": 16.473539635356595
         },
         {
             "id": "67d935b5d6d3ce76bef2c95c",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8e1",
                 "67d935b0d6d3ce76bef2c8d9"
-            ]
+            ],
+            "latitude": 18.012335953973512,
+            "longitude": 57.827276660203175
         },
         {
             "id": "67d935b5d6d3ce76bef2c95d",
             "rooms": [
                 "67d935b1d6d3ce76bef2c8e2",
                 "67d935b0d6d3ce76bef2c8d9"
-            ]
+            ],
+            "latitude": 71.90524108637193,
+            "longitude": 47.32741515453846
         },
         {
             "id": "67d935b5d6d3ce76bef2c95e",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8d8",
                 "67d935b0d6d3ce76bef2c8da"
-            ]
+            ],
+            "latitude": 45.93720669792249,
+            "longitude": 55.67537250049806
         },
         {
             "id": "67d935b5d6d3ce76bef2c95f",
             "rooms": [
                 "67d935aed6d3ce76bef2c893",
                 "67d935b0d6d3ce76bef2c8da"
-            ]
+            ],
+            "latitude": 53.312703306107444,
+            "longitude": 33.16791854606613
         },
         {
             "id": "67d935b5d6d3ce76bef2c960",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8d9",
                 "67d935b0d6d3ce76bef2c8db"
-            ]
+            ],
+            "latitude": 37.538782960601026,
+            "longitude": 18.93777352124124
         },
         {
             "id": "67d935b5d6d3ce76bef2c961",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8de",
                 "67d935b0d6d3ce76bef2c8df"
-            ]
+            ],
+            "latitude": 10.404483061758405,
+            "longitude": 62.51497781591165
         },
         {
             "id": "67d935b5d6d3ce76bef2c962",
             "rooms": [
                 "67d935b0d6d3ce76bef2c8e1",
                 "67d935b1d6d3ce76bef2c8e2"
-            ]
+            ],
+            "latitude": 27.37386615753772,
+            "longitude": 22.2430414574675
         }
     ],
     "source_sensor": "67d935b5d6d3ce76bef2c960",

--- a/app/test/mock_data/rooms_and_sensors_no_path.json
+++ b/app/test/mock_data/rooms_and_sensors_no_path.json
@@ -31,25 +31,33 @@
             "rooms": [
                 "67d935add6d3ce76bef2c881",
                 "67d935afd6d3ce76bef2c8a8"
-            ]
+            ],
+            "latitude": 49.312392999049514,
+            "longitude": 53.68807434882344
         },
         {
             "id": "67d935b5d6d3ce76bef2c960",
             "rooms": [
                 "67d935add6d3ce76bef2c881"
-            ]
+            ],
+            "latitude": 60.30540443182037,
+            "longitude": 26.612303468186102
         },
         {
             "id": "67d935b5d6d3ce76bef2c961",
             "rooms": [
                 "67d935add6d3ce76bef2c881"
-            ]
+            ],
+            "latitude": 77.95709819790915,
+            "longitude": 30.55809870535711
         },
         {
             "id": "no_path_sensor",
             "rooms": [
                 "room1"
-            ]
+            ],
+            "latitude": 44.515457430535754,
+            "longitude": 14.639179911121865
         }
     ],
     "source_sensor": "no_path_sensor",

--- a/app/test/mock_data/rooms_and_sensors_no_path.json
+++ b/app/test/mock_data/rooms_and_sensors_no_path.json
@@ -1,55 +1,62 @@
 {
   "rooms": [
       {
-        "id": "67d935add6d3ce76bef2c881",
-        "name": "RW1",
-        "crowd_factor": 0.3,
-        "occupants": 2,
-        "area": 50.0
+          "id": "67d935add6d3ce76bef2c881",
+          "name": "RW1",
+          "crowd_factor": 0.3,
+          "occupants": 2,
+          "area": 50.0
       },
       {
-        "id": "67d935afd6d3ce76bef2c8a8",
-        "name": "RW2",
-        "crowd_factor": 0.5,
-        "occupants": 3,
-        "area": 70.0
+          "id": "67d935afd6d3ce76bef2c8a8",
+          "name": "RW2",
+          "crowd_factor": 0.5,
+          "occupants": 3,
+          "area": 70.0
       },
       {
-        "id": "room1",
-        "name": "NoPath",
-        "crowd_factor": 0.5,
-        "occupants": 2,
-        "area": 50.0
+          "id": "room1",
+          "name": "NoPath",
+          "crowd_factor": 0.5,
+          "occupants": 2,
+          "area": 50.0
       }
-    ],
-    "sensors": [
+  ],
+  "sensors": [
       {
-        "id": "67d935b1d6d3ce76bef2c8e3",
-        "rooms": [
-          "67d935add6d3ce76bef2c881",
-          "67d935afd6d3ce76bef2c8a8"
-        ]
+          "id": "67d935b1d6d3ce76bef2c8e3",
+          "rooms": [
+              "67d935add6d3ce76bef2c881",
+              "67d935afd6d3ce76bef2c8a8"
+          ],
+          "latitude": 67.7779753615802,
+          "longitude": 52.28848795017501
       },
       {
-        "id": "67d935b5d6d3ce76bef2c960",
-        "rooms": [
-          "67d935add6d3ce76bef2c881"
-        ]
+          "id": "67d935b5d6d3ce76bef2c960",
+          "rooms": [
+              "67d935add6d3ce76bef2c881"
+          ],
+          "latitude": 38.72545358053907,
+          "longitude": 53.22798949051648
       },
       {
-        "id": "67d935b5d6d3ce76bef2c961",
-        "rooms": [
-          "67d935add6d3ce76bef2c881"
-        ]
+          "id": "67d935b5d6d3ce76bef2c961",
+          "rooms": [
+              "67d935add6d3ce76bef2c881"
+          ],
+          "latitude": 71.0429035502413,
+          "longitude": 52.7535073735901
       },
       {
-        "id": "no_path_sensor",
-        "rooms": [
-          "room1"
-        ]
+          "id": "no_path_sensor",
+          "rooms": [
+              "room1"
+          ],
+          "latitude": 21.31620526181467,
+          "longitude": 59.15320892560297
       }
-    ],
-    "source_sensor": "no_path_sensor",
-    "target_sensor": "67d935b5d6d3ce76bef2c961"
-  }
-  
+  ],
+  "source_sensor": "no_path_sensor",
+  "target_sensor": "67d935b5d6d3ce76bef2c961"
+}

--- a/app/test/routes/test_pathfinding.py
+++ b/app/test/routes/test_pathfinding.py
@@ -24,7 +24,7 @@ def test_pathfinding_returns_correct_path(load_mock_payload):
 
     assert response.status_code == 200
     data = response.json()
-    assert data['fastest_path'] == ['67d935b5d6d3ce76bef2c960', '67d935b5d6d3ce76bef2c95a', '67d935b5d6d3ce76bef2c961']
+    assert data['fastest_path'] == [{'id': '67d935b5d6d3ce76bef2c960', 'longtitude': 0.0, 'latitude': 0.0}, {'id': '67d935b5d6d3ce76bef2c95a', 'longtitude': 0.0, 'latitude': 0.0}, {'id': '67d935b5d6d3ce76bef2c961', 'longtitude': 0.0, 'latitude': 0.0}]
     assert data['distance'] == 0.342
 
 

--- a/app/test/routes/test_pathfinding.py
+++ b/app/test/routes/test_pathfinding.py
@@ -24,7 +24,7 @@ def test_pathfinding_returns_correct_path(load_mock_payload):
 
     assert response.status_code == 200
     data = response.json()
-    assert data['fastest_path'] == [{'id': '67d935b5d6d3ce76bef2c960', 'longitude': 10.857185147851341, 'latitude': 11.032101366333102}, {'id': '67d935b5d6d3ce76bef2c95a', 'longitude': 47.31982729135278, 'latitude': 42.8210378030866}, {'id': '67d935b5d6d3ce76bef2c961', 'longitude': 64.81348685573096, 'latitude': 20.355786846137036}]
+    assert data['fastest_path'] == [{'id': '67d935b5d6d3ce76bef2c960', 'longitude': 18.93777352124124, 'latitude': 37.538782960601026}, {'id': '67d935b5d6d3ce76bef2c95a', 'longitude': 25.297401708592176, 'latitude': 67.80276018830894}, {'id': '67d935b5d6d3ce76bef2c961', 'longitude': 62.51497781591165, 'latitude': 10.404483061758405}]
     assert data['distance'] == 0.342
 
 

--- a/app/test/routes/test_pathfinding.py
+++ b/app/test/routes/test_pathfinding.py
@@ -24,7 +24,7 @@ def test_pathfinding_returns_correct_path(load_mock_payload):
 
     assert response.status_code == 200
     data = response.json()
-    assert data['fastest_path'] == [{'id': '67d935b5d6d3ce76bef2c960', 'longtitude': 0.0, 'latitude': 0.0}, {'id': '67d935b5d6d3ce76bef2c95a', 'longtitude': 0.0, 'latitude': 0.0}, {'id': '67d935b5d6d3ce76bef2c961', 'longtitude': 0.0, 'latitude': 0.0}]
+    assert data['fastest_path'] == [{'id': '67d935b5d6d3ce76bef2c960', 'longitude': 10.857185147851341, 'latitude': 11.032101366333102}, {'id': '67d935b5d6d3ce76bef2c95a', 'longitude': 47.31982729135278, 'latitude': 42.8210378030866}, {'id': '67d935b5d6d3ce76bef2c961', 'longitude': 64.81348685573096, 'latitude': 20.355786846137036}]
     assert data['distance'] == 0.342
 
 

--- a/app/test/services/test_route_service.py
+++ b/app/test/services/test_route_service.py
@@ -53,5 +53,5 @@ def test_fastest_path_success(load_mock_payload):
     assert 'distance' in result
     assert isinstance(result['fastest_path'], list)
     assert isinstance(result['distance'], (int, float))
-    assert result['fastest_path'] == [{'id': '67d935b5d6d3ce76bef2c960', 'longitude': 10.857185147851341, 'latitude': 11.032101366333102}, {'id': '67d935b5d6d3ce76bef2c95a', 'longitude': 47.31982729135278, 'latitude': 42.8210378030866}, {'id': '67d935b5d6d3ce76bef2c961', 'longitude': 64.81348685573096, 'latitude': 20.355786846137036}]
+    assert result['fastest_path'] == [{'id': '67d935b5d6d3ce76bef2c960', 'longitude': 18.93777352124124, 'latitude': 37.538782960601026}, {'id': '67d935b5d6d3ce76bef2c95a', 'longitude': 25.297401708592176, 'latitude': 67.80276018830894}, {'id': '67d935b5d6d3ce76bef2c961', 'longitude': 62.51497781591165, 'latitude': 10.404483061758405}]
     assert pytest.approx(result['distance']) == 0.342

--- a/app/test/services/test_route_service.py
+++ b/app/test/services/test_route_service.py
@@ -53,5 +53,5 @@ def test_fastest_path_success(load_mock_payload):
     assert 'distance' in result
     assert isinstance(result['fastest_path'], list)
     assert isinstance(result['distance'], (int, float))
-    assert result['fastest_path'] == ['67d935b5d6d3ce76bef2c960', '67d935b5d6d3ce76bef2c95a', '67d935b5d6d3ce76bef2c961']
+    assert result['fastest_path'] == [{'id': '67d935b5d6d3ce76bef2c960', 'longtitude': 0.0, 'latitude': 0.0}, {'id': '67d935b5d6d3ce76bef2c95a', 'longtitude': 0.0, 'latitude': 0.0}, {'id': '67d935b5d6d3ce76bef2c961', 'longtitude': 0.0, 'latitude': 0.0}]
     assert pytest.approx(result['distance']) == 0.342

--- a/app/test/services/test_route_service.py
+++ b/app/test/services/test_route_service.py
@@ -53,5 +53,5 @@ def test_fastest_path_success(load_mock_payload):
     assert 'distance' in result
     assert isinstance(result['fastest_path'], list)
     assert isinstance(result['distance'], (int, float))
-    assert result['fastest_path'] == [{'id': '67d935b5d6d3ce76bef2c960', 'longtitude': 0.0, 'latitude': 0.0}, {'id': '67d935b5d6d3ce76bef2c95a', 'longtitude': 0.0, 'latitude': 0.0}, {'id': '67d935b5d6d3ce76bef2c961', 'longtitude': 0.0, 'latitude': 0.0}]
+    assert result['fastest_path'] == [{'id': '67d935b5d6d3ce76bef2c960', 'longitude': 10.857185147851341, 'latitude': 11.032101366333102}, {'id': '67d935b5d6d3ce76bef2c95a', 'longitude': 47.31982729135278, 'latitude': 42.8210378030866}, {'id': '67d935b5d6d3ce76bef2c961', 'longitude': 64.81348685573096, 'latitude': 20.355786846137036}]
     assert pytest.approx(result['distance']) == 0.342

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 pythonpath = .
-addopts = --import-mode=importlib --cov=app --cov-branch
+; addopts = --import-mode=importlib --cov=app --cov-branch

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 pythonpath = .
-; addopts = --import-mode=importlib --cov=app --cov-branch
+addopts = --import-mode=importlib --cov=app --cov-branch


### PR DESCRIPTION
This pull request introduces changes to the `Sensor` class to include geographical coordinates and updates the related methods, tests, and data accordingly. The primary focus is on adding `longitude` and `latitude` attributes to the `Sensor` class and ensuring that these attributes are utilized throughout the codebase.

### Changes to Sensor Class:
* [`app/classes/sensor.py`](diffhunk://#diff-98906d07c09411ab47b33866ee6a26f6e20d0e030db2bc738e8313910182f3daL2-R24): Added `longitude` and `latitude` attributes to the `Sensor` class and updated the `__init__`, `from_dict`, and `from_schema` methods to handle these new attributes.

### Updates to Pathfinding:
* [`app/classes/sensor_graph.py`](diffhunk://#diff-ceb90e18cc33f771b88b66d13c001e4d8bad274677cf60c8ff722ca66c508fb9R49-R59): Modified the `find_fastest_path` method to return the path with sensor coordinates instead of just sensor IDs.

### Schema Changes:
* [`app/schemas/sensor.py`](diffhunk://#diff-0620172e2f28abc68e1ed85b87fc2b292c82c9653eeaacd8a4acd7c59969ad82L8-R9): Added `longitude` and `latitude` fields to the `SensorSchema` class.

### Test Updates:
* [`app/test/classes/test_sensor.py`](diffhunk://#diff-28422e7de440b2293354b24df17f8bfb09fc7187ab9ec32074f314c6b2d6f95dL7-R15): Updated tests to include `longitude` and `latitude` when creating `Sensor` instances. [[1]](diffhunk://#diff-28422e7de440b2293354b24df17f8bfb09fc7187ab9ec32074f314c6b2d6f95dL7-R15) [[2]](diffhunk://#diff-24a2e8b4ce462d141424d2e78459514431cf682b46e9ecc5acda190a4ca46fefL19-R30) [[3]](diffhunk://#diff-24a2e8b4ce462d141424d2e78459514431cf682b46e9ecc5acda190a4ca46fefL65-R67) [[4]](diffhunk://#diff-24a2e8b4ce462d141424d2e78459514431cf682b46e9ecc5acda190a4ca46fefL83-R87) [[5]](diffhunk://#diff-24a2e8b4ce462d141424d2e78459514431cf682b46e9ecc5acda190a4ca46fefL103-R105)
* [`app/test/mock_data/rooms_and_sensors_no_path.json`](diffhunk://#diff-c7339dd2857cc865be34931e9e8e7ed89da53945b45e0b0f738d2c7b8298b735L34-R60): Added `longitude` and `latitude` to the mock sensor data.
* [`app/test/routes/test_pathfinding.py`](diffhunk://#diff-8ba5255aaa97fdeaab98e2272a69f807d6cece34bcc2721d4f0e53e6b365ad01L27-R27): Updated pathfinding test to validate the path with coordinates.
* [`app/test/services/test_route_service.py`](diffhunk://#diff-ad968d4e4d34d6a133a6f95b0f890e434cf7fc5deefeb07c26882abc18919482L56-R56): Updated the test for the fastest path service to check for coordinates in the path.