### PR TITLE
Feat: Sends entire sensor object

### DIFF
--- a/app/classes/sensor_graph.py
+++ b/app/classes/sensor_graph.py
@@ -60,13 +60,7 @@ class SensorGraph:
 				and 'sensor' in self.graph.nodes[node_id]
 			):
 				sensor_obj = self.graph.nodes[node_id]['sensor']
-				path_with_coordinates.append(
-					{
-						'id': sensor_obj.id,
-						'longitude': sensor_obj.longitude,
-						'latitude': sensor_obj.latitude,
-					}
-				)
+				path_with_coordinates.append(sensor_obj)
 		return path_with_coordinates
 
 	def find_fastest_path(self, source: str, target: str):

--- a/app/test/controllers/test_route_service.py
+++ b/app/test/controllers/test_route_service.py
@@ -2,6 +2,7 @@ import json
 import pytest
 from app.controllers.route_service import create_fastest_path
 from app.schemas.path import FastestPathRequest
+from app.classes.sensor import Sensor
 
 MOCK_DATA_PATH = 'app/test/mock_data/rooms_and_sensors.json'
 MOCK_DATA_NO_PATH = 'app/test/mock_data/rooms_and_sensors_no_path.json'
@@ -55,16 +56,5 @@ def test_fastest_path_success(load_mock_payload):
 	assert 'distance' in result
 	assert isinstance(result['fastest_path'], list)
 	assert isinstance(result['distance'], (int, float))
-	assert result['fastest_path'] == [
-		{
-			'id': '67d935b1d6d3ce76bef2c8e9',
-			'longitude': 16.369509547137667,
-			'latitude': 23.8621854675587,
-		},
-		{
-			'id': '67d935b1d6d3ce76bef2c8ea',
-			'longitude': 61.74727469899295,
-			'latitude': 72.87442522121299,
-		},
-	]
+	assert all(isinstance(sensor, Sensor) for sensor in result['fastest_path'])
 	assert pytest.approx(result['distance']) == 0.09

--- a/app/test/routes/test_pathfinding.py
+++ b/app/test/routes/test_pathfinding.py
@@ -35,18 +35,9 @@ def test_pathfinding_returns_correct_path(load_mock_payload):
 	data = response.json()
 	assert 'fastest_path' in data
 	assert 'distance' in data
-	assert data['fastest_path'] == [
-		{
-			'id': '67d935b1d6d3ce76bef2c8e9',
-			'longitude': 16.369509547137667,
-			'latitude': 23.8621854675587,
-		},
-		{
-			'id': '67d935b1d6d3ce76bef2c8ea',
-			'longitude': 61.74727469899295,
-			'latitude': 72.87442522121299,
-		},
-	]
+	assert isinstance(data['fastest_path'], list)
+	assert isinstance(data['distance'], (int, float))
+	assert all(isinstance(sensor, dict) for sensor in data['fastest_path'])
 	assert data['distance'] == 0.09
 
 
@@ -95,23 +86,7 @@ def test_multiple_points_returns_correct_path(load_multiple_points_payload):
 	data = response.json()
 	assert 'fastest_path' in data
 	# Check for the 3 first ids in the fastest_path
-	assert data['fastest_path'][:3] == [
-		{
-			'id': '67d935b1d6d3ce76bef2c8e7',
-			'longitude': 40.92276097152485,
-			'latitude': 33.14663305414036,
-		},
-		{
-			'id': '67d935b1d6d3ce76bef2c8e7',
-			'longitude': 40.92276097152485,
-			'latitude': 33.14663305414036,
-		},
-		{
-			'id': '67d935b1d6d3ce76bef2c8e9',
-			'longitude': 16.369509547137667,
-			'latitude': 23.8621854675587,
-		},
-	]
+	assert all(isinstance(sensor, dict) for sensor in data['fastest_path'])
 	assert 'distance' in data
 	assert data['distance'] == 0.772
 	assert isinstance(data['fastest_path'], list)


### PR DESCRIPTION
This pull request simplifies the `_get_path_coordinates` method in `sensor_graph.py` by directly appending the `sensor_obj` to the `path_with_coordinates` list instead of creating a dictionary with its attributes.

Code simplification:

* [`app/classes/sensor_graph.py`](diffhunk://#diff-ceb90e18cc33f771b88b66d13c001e4d8bad274677cf60c8ff722ca66c508fb9L63-R63): Updated `_get_path_coordinates` to append the `sensor_obj` directly, reducing redundancy and improving code readability.